### PR TITLE
feat: add recon early stopping knobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,25 @@ p0 = forward_project_view(geom, grid, det, vol, view_index=0)
 
 # FBP and FISTA reconstructions
 x_fbp = fbp(geom, grid, det, p0[None, ...])
-x_fista, info = fista_tv(geom, grid, det, p0[None, ...], iters=10, lambda_tv=0.001)
+x_fista, info = fista_tv(
+    geom,
+    grid,
+    det,
+    p0[None, ...],
+    iters=10,
+    lambda_tv=0.001,
+    recon_rel_tol=1e-4,
+    recon_patience=3,
+)
 
 # Alignment (toy 1-view example; use many views in practice)
-cfg = AlignConfig(outer_iters=1, recon_iters=5, lambda_tv=0.001)
+cfg = AlignConfig(
+    outer_iters=1,
+    recon_iters=5,
+    lambda_tv=0.001,
+    recon_rel_tol=1e-4,
+    recon_patience=3,
+)
 x_aligned, params5, info = align(geom, grid, det, p0[None, ...], cfg=cfg)
 ```
 
@@ -145,6 +160,8 @@ See `docs/schema_nxtomo.md` for the HDF5/NXtomo format used by the CLIs.
 - Mixed precision gather (`--gather-dtype bf16`) reduces bandwidth while accumulating in fp32.
 - To avoid JAX preallocation spikes: `export XLA_PYTHON_CLIENT_PREALLOCATE=false`.
 - For noisy data, increase `--lambda-tv` and consider raising `--tv-prox-iters` to 20–30 to strengthen the TV proximal step.
+- When the FISTA loss stabilizes, set `AlignConfig.recon_rel_tol` / `recon_patience` (or pass the same kwargs to `fista_tv`) to
+  terminate reconstructions early and skip redundant iterations.
 
 Troubleshooting tips live in `docs/faq_troubleshooting.md`.
 

--- a/guide.md
+++ b/guide.md
@@ -33,3 +33,6 @@ Further details:
 - Tutorial: `docs/tutorial_end_to_end.md`
 - Data schema: `docs/schema_nxtomo.md`
 - FAQ/Troubleshooting: `docs/faq_troubleshooting.md`
+
+Tip: expose `recon_rel_tol` / `recon_patience` via `AlignConfig`
+(or pass them directly to `fista_tv`) to short-circuit reconstructions once the objective plateaus.

--- a/src/tomojax/align/pipeline.py
+++ b/src/tomojax/align/pipeline.py
@@ -21,6 +21,9 @@ class AlignConfig:
     recon_iters: int = 10
     lambda_tv: float = 0.005
     tv_prox_iters: int = 10
+    # Reconstruction stopping criteria
+    recon_rel_tol: float | None = None
+    recon_patience: int = 2
     # Alignment step sizes
     lr_rot: float = 1e-3  # radians
     lr_trans: float = 1e-1  # world units
@@ -258,6 +261,10 @@ def align(
                 gather_dtype=gather,
                 grad_mode=gm,
                 tv_prox_iters=int(cfg.tv_prox_iters),
+                recon_rel_tol=cfg.recon_rel_tol,
+                recon_patience=(
+                    int(cfg.recon_patience) if cfg.recon_patience is not None else 0
+                ),
             )
 
         vpb0 = (cfg.views_per_batch if cfg.views_per_batch > 0 else None)
@@ -502,6 +509,10 @@ def align_multires(
                 projector_unroll=int(cfg.projector_unroll),
                 checkpoint_projector=cfg.checkpoint_projector,
                 gather_dtype=cfg.gather_dtype,
+                recon_rel_tol=cfg.recon_rel_tol,
+                recon_patience=(
+                    int(cfg.recon_patience) if cfg.recon_patience is not None else 0
+                ),
             )
             T_nom = jnp.stack(
                 [jnp.asarray(geometry.pose_for_view(i), dtype=jnp.float32) for i in range(y.shape[0])],


### PR DESCRIPTION
## Summary
- add reconstruction early-stopping knobs to `AlignConfig` and plumb them into the alignment pipeline
- extend `fista_tv` with tolerance/patience handling, loss tracking, and metadata about effective iterations
- document the new configuration options and add a regression test that ensures FISTA stops once its loss plateaus

## Testing
- pixi run python -m pytest -q tests/test_recon.py *(fails: `pixi` not available in container)*
- python -m pytest -q tests/test_recon.py *(fails: missing numpy dependency outside pixi environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd03ccc57c8325bcad69b028837fcf