### PR TITLE
feat(laminography): sample‑frame recon, lamino slab fix, 360° span, CLI frame/rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ Notes
 - Trilinear interpolation with analytical derivatives
 - CPU/GPU support via JIT
 
+### Laminography (Parallel‑Beam)
+- Tilted rotation‑axis geometry (x/z tilt) with consistent sample‑frame parametrization
+- Simulation helpers for thin‑slab phantoms aligned to the sample rotation axis
+- Default 360° rotation span (configurable via `--rotation-deg`)
+- Reconstructions saved in the sample frame by default (FBP and FISTA‑TV)
+- Tutorial: `docs/tutorial_laminography.md`
+
 ### Joint Reconstruction & Alignment
 - Multi‑resolution: hierarchical optimisation (e.g., 4× → 2× → 1×)
 - Alternating steps: FISTA‑TV reconstruction + per‑view alignment
@@ -69,6 +76,9 @@ pixi run align    ...
 # Full step‑by‑step tutorial
 less docs/tutorial_end_to_end.md
 
+# Laminography tutorial
+less docs/tutorial_laminography.md
+
 # CLI reference
 less docs/cli_reference.md
 ```
@@ -76,13 +86,22 @@ less docs/cli_reference.md
 Common examples
 
 ```bash
-# Simulate a 256³ phantom and projections
+# Simulate a 256³ phantom and projections (parallel CT)
 pixi run simulate \
   --out data/sim_aligned.nxs \
   --nx 256 --ny 256 --nz 256 \
   --nu 256 --nv 256 --n-views 200 \
   --phantom random_shapes --n-cubes 40 --n-spheres 40 \
   --min-size 4 --max-size 64 --min-value 0.01 --max-value 0.1 --seed 42
+
+# Simulate laminography (tilt about x, 360°)
+pixi run simulate \
+  --out runs/lamino_demo.nxs \
+  --nx 128 --ny 128 --nz 128 \
+  --nu 128 --nv 128 --n-views 360 \
+  --geometry lamino --tilt-deg 35 --tilt-about x \
+  --phantom lamino_disk --lamino-thickness-ratio 0.15 \
+  --n-cubes 60 --n-spheres 60 --min-size 4 --max-size 14 --seed 3
 
 # Create misaligned (and optionally noisy) projections
 pixi run misalign --data data/sim_aligned.nxs --out data/sim_misaligned.nxs \

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -18,6 +18,7 @@ python -m tomojax.cli.simulate --out <path.nxs> \
   --nx <int> --ny <int> --nz <int> \
   --nu <int> --nv <int> --n-views <int> \
   [--geometry parallel|lamino] [--tilt-deg <float>] [--tilt-about x|z] \
+  [--rotation-deg <float>] \
   [--phantom shepp|cube|blobs|random_shapes] [phantom-args...] \
   [--noise none|gaussian|poisson] [--noise-level <float>] \
   [--seed <int>] [--progress]
@@ -25,6 +26,7 @@ python -m tomojax.cli.simulate --out <path.nxs> \
 
 Key options
 - Geometry: `--geometry parallel` (default) or `lamino` with `--tilt-deg` (default 30) about axis `--tilt-about` (`x` default).
+- Rotation span: `--rotation-deg` sets the total angular range. Defaults to 180 for `parallel` and 360 for `lamino`.
 - Phantom: `--phantom random_shapes` with controls:
   - `--n-cubes` (8), `--n-spheres` (7), `--min-size` (4), `--max-size` (32)
   - `--min-value` (0.1), `--max-value` (1.0), `--max-rot-deg` (180)
@@ -79,7 +81,7 @@ python -m tomojax.cli.recon --data <in.nxs> \
   [--iters <int>] [--lambda-tv <float>] [--tv-prox-iters <int>] [--L <float>] \
   [--views-per-batch <int|auto>] [--projector-unroll <int>] \
   [--gather-dtype fp32|bf16|fp16] [--checkpoint-projector|--no-checkpoint-projector] \
-  --out <out.nxs> [--progress]
+  --out <out.nxs> [--frame sample|lab] [--progress]
 ```
 
 Key options
@@ -87,6 +89,7 @@ Key options
 - FBP filter: `--filter ramp` (aliases: ram‑lak/ramlak), `shepp`, `hann`.
 - FISTA: `--iters` (50), `--lambda-tv` (0.005), `--tv-prox-iters` (10) controls the inner TV proximal iterations (use 20–30 for heavy noise), optional fixed `--L` to skip power‑method.
 - Memory/performance: `--views-per-batch auto` (recommended), `--projector-unroll` (1–4), `--gather-dtype` (bf16 recommended on modern GPUs), projector checkpointing on by default.
+- Frame: `--frame sample` (default; recommended) records that the saved volume is in the sample/object frame. `lab` is recorded for compatibility exports.
 
 Examples
 ```

--- a/docs/faq_troubleshooting.md
+++ b/docs/faq_troubleshooting.md
@@ -66,3 +66,15 @@
     --levels 4 2 1 --outer-iters 15 --lambda-tv 0.005 \
     --opt-method gn --gn-damping 1e-3 --seed-translations
   ```
+
+## Laminography specifics
+
+- Recon volume orientation looks “wrong” in a viewer:
+  - TomoJAX saves volumes in the sample frame (x,y,z). Some viewers assume a different axis order. If needed, transpose axes when viewing or export with a desired order. The NX attribute `/entry/processing/tomojax@frame` records the intended frame.
+  - For laminography, slices advance parallel to the rotation axis (thin slab visible in each slice).
+
+- Why 360° for laminography?
+  - Parallel‑beam laminography benefits from full 360° coverage. Use `--rotation-deg 360` (default for `--geometry lamino`). Tomography defaults to 180°.
+
+- No alignment progress shown:
+  - Use `--progress --log-summary` to see per‑outer summaries and keep bars visible by setting `TOMOJAX_PROGRESS_LEAVE=1`.

--- a/docs/schema_nxtomo.md
+++ b/docs/schema_nxtomo.md
@@ -21,18 +21,20 @@ Primary file type: HDF5 with NeXus NXtomo conventions. Default extension: `.nxs`
 
 ## TomoJAX Extras
 - `/entry/geometry/type = "parallel" | "lamino" | "custom"`
+- `/entry/geometry/@geometry_meta_json` (optional): JSON with geometry‑specific metadata, e.g., for laminography `{ "tilt_deg": <float>, "tilt_about": "x"|"z" }`
 - `/entry/@grid_meta_json`: JSON-serialized Grid
   - `{ nx, ny, nz, vx, vy, vz, vol_origin?, vol_center? }`
 - `/entry/instrument/detector/@detector_meta_json`: JSON-serialized Detector
   - `{ nu, nv, du, dv, det_center }`
 - `/entry/processing (NXprocess)/tomojax (NXcollection)`
-  - `volume` (optional GT, shape `(nz,ny,nx)`, compression `lzf`)
+  - `volume` (optional GT or reconstruction, shape `(nx,ny,nz)`, compression `lzf`)
+  - `@frame` (optional attr on `tomojax`): `"sample"|"lab"` indicates the frame of the saved volume (default `sample`)
   - `align/thetas` (optional, shape `(n_views,5)`, columns=`[alpha,beta,phi,dx,dz]`)
 
 ## Units & Conventions
 - Angles stored in degrees (NX convention). Internal math uses radians.
 - Voxel/detector sizes: units `pixel` for simulated data unless specified.
-- Rotation axis defaults to world +z; laminography adds tilt via geometry metadata.
+- Transformations: `rotation_angle` is stored in degrees; a default `rotation_axis=[0,0,1]` is written for NX compatibility. The exact geometry (e.g., laminography tilt) is described in `/entry/geometry` and used by TomoJAX.
 
 ## Notes
 - Use `lzf` compression by default; `gzip(level=4)` for smaller files if needed.

--- a/docs/tutorial_laminography.md
+++ b/docs/tutorial_laminography.md
@@ -1,0 +1,116 @@
+# Laminography End-to-End Tutorial (Draft)
+
+This guide mirrors the tomography walkthrough but focuses on the laminography
+workflow: generating a thin specimen, simulating a tilted-axis scan, and running
+FBP/FISTA reconstructions with the new geometry support.
+
+> **Prerequisites**
+> - You have a working TomoJAX checkout and the `pixi` environment installed.
+> - JAX can see either a GPU or the CPU backend (set `JAX_PLATFORM_NAME=cpu`
+>   if your system lacks CUDA libraries).
+
+## 1. Environment
+
+```bash
+pixi install          # one-time dependency install
+pixi shell            # enter the managed environment
+pixi run test-cpu     # optional sanity check (use test-gpu if CUDA is ready)
+```
+
+## 2. Simulate a Laminography Dataset
+
+We use the `lamino_disk` phantom, which clamps voxel intensities to a thin slab
+orthogonal to the laminography rotation axis.
+
+```bash
+pixi run simulate \
+  --out runs/lamino_demo.nxs \
+  --nx 256 --ny 256 --nz 256 \
+  --nu 256 --nv 256 --n-views 360 \
+  --geometry lamino \
+  --tilt-deg 35 --tilt-about x \
+  --phantom lamino_disk \
+  --lamino-thickness-ratio 0.15 \
+  --n-cubes 80 --n-spheres 80 \
+  --min-size 4 --max-size 14 \
+  --seed 3
+```
+
+Key metadata written to the NXtomo file:
+
+- `/entry/geometry/type = "lamino"`
+- `/entry/geometry/geometry_meta_json` with `tilt_deg` and `tilt_about`
+- Ground-truth volume constrained to a thin slab.
+
+## 3. Filtered Backprojection (FBP)
+
+The reconstruction CLI automatically rebuilds either a parallel or laminography
+geometry from the metadata:
+
+```bash
+pixi run python -m tomojax.cli.recon \
+  --data runs/lamino_demo.nxs \
+  --algo fbp \
+  --filter ramp \
+  --views-per-batch auto \
+  --out runs/lamino_demo_fbp.nxs
+```
+
+The result is stored under `/entry/processing/tomojax/volume`. Use tools such
+as `scripts/volume_slice.py` or your favourite viewer to inspect the slices.
+
+## 4. TV-Regularised FISTA Reconstruction
+
+```bash
+pixi run python -m tomojax.cli.recon \
+  --data runs/lamino_demo.nxs \
+  --algo fista \
+  --iters 75 \
+  --lambda-tv 1e-3 \
+  --tv-prox-iters 20 \
+  --views-per-batch auto \
+  --projector-unroll 2 \
+  --out runs/lamino_demo_fista.nxs
+```
+
+Monitor the log output for the FISTA loss curve. If you are memory-limited,
+reduce `views-per-batch`, disable checkpointing, or switch to `gather-dtype
+bf16/fp16`.
+
+## 5. Optional: Misalignment Stress Test
+
+```bash
+pixi run misalign \
+  --data runs/lamino_demo.nxs \
+  --out runs/lamino_demo_misaligned.nxs \
+  --rot-deg 0.5 \
+  --trans-px 4 \
+  --seed 11
+
+pixi run align \
+  --data runs/lamino_demo_misaligned.nxs \
+  --outer-iters 4 --recon-iters 20 \
+  --lambda-tv 5e-3 --tv-prox-iters 15 \
+  --opt-method gn --gn-damping 1e-3 \
+  --views-per-batch auto \
+  --out runs/lamino_demo_aligned.nxs
+```
+
+The alignment CLI automatically honours the stored laminography tilt. Compare
+`/entry/processing/tomojax/align/thetas` before/after to quantify alignment
+improvements.
+
+## 6. Tips & Next Steps
+
+- For analytic benchmarking, keep the voxel spacing isotropic and the detector
+  sampling identical along the thin axis to avoid anisotropic discretisation
+  artefacts.
+- If you plan to extend this tutorial (e.g. multiresolution alignment or
+  custom phantoms), copy the commands above and adjust only the relevant
+  parameters.
+- Contributions welcome: open an issue with feedback or ideas for additional
+  laminography examples.
+
+---
+
+*Last updated:* WIP — expect changes as laminography support evolves.

--- a/docs/tutorial_laminography.md
+++ b/docs/tutorial_laminography.md
@@ -1,116 +1,105 @@
-# Laminography End-to-End Tutorial (Draft)
+# Laminography End-to-End Tutorial
 
-This guide mirrors the tomography walkthrough but focuses on the laminography
-workflow: generating a thin specimen, simulating a tilted-axis scan, and running
-FBP/FISTA reconstructions with the new geometry support.
+This guide focuses on laminography: simulate a thin slab, run FBP for a sanity check, generate misaligned variants (clean and noisy), then align and reconstruct.
 
-> **Prerequisites**
-> - You have a working TomoJAX checkout and the `pixi` environment installed.
-> - JAX can see either a GPU or the CPU backend (set `JAX_PLATFORM_NAME=cpu`
->   if your system lacks CUDA libraries).
+Prerequisites
+- pixi installed and environment set up
+- Optional: set JAX_PLATFORM_NAME=cpu if CUDA libraries aren’t available
 
-## 1. Environment
-
-```bash
-pixi install          # one-time dependency install
-pixi shell            # enter the managed environment
-pixi run test-cpu     # optional sanity check (use test-gpu if CUDA is ready)
-```
-
-## 2. Simulate a Laminography Dataset
-
-We use the `lamino_disk` phantom, which clamps voxel intensities to a thin slab
-orthogonal to the laminography rotation axis.
-
+## Simulate laminography dataset
 ```bash
 pixi run simulate \
-  --out runs/lamino_demo.nxs \
-  --nx 256 --ny 256 --nz 256 \
-  --nu 256 --nv 256 --n-views 360 \
-  --geometry lamino \
-  --tilt-deg 35 --tilt-about x \
-  --phantom lamino_disk \
-  --lamino-thickness-ratio 0.15 \
-  --n-cubes 80 --n-spheres 80 \
-  --min-size 4 --max-size 14 \
-  --seed 3
+--out runs/lamino_demo.nxs \
+--nx 128 --ny 128 --nz 128 \
+--nu 128 --nv 128 --n-views 360 \
+--geometry lamino \
+--tilt-deg 35 --tilt-about x \
+--phantom lamino_disk \
+--lamino-thickness-ratio 0.15 \
+--n-cubes 100 --n-spheres 100 \
+--min-size 4 --max-size 32 \
+--seed 3
 ```
 
-Key metadata written to the NXtomo file:
+Notes
+- Saves the ground-truth volume in the sample frame (object coordinates).
+- For laminography, the default rotation span is 360°.
 
-- `/entry/geometry/type = "lamino"`
-- `/entry/geometry/geometry_meta_json` with `tilt_deg` and `tilt_about`
-- Ground-truth volume constrained to a thin slab.
-
-## 3. Filtered Backprojection (FBP)
-
-The reconstruction CLI automatically rebuilds either a parallel or laminography
-geometry from the metadata:
-
+## Recon clean dataset with FBP - sanity check
 ```bash
 pixi run python -m tomojax.cli.recon \
-  --data runs/lamino_demo.nxs \
-  --algo fbp \
-  --filter ramp \
-  --views-per-batch auto \
-  --out runs/lamino_demo_fbp.nxs
+--data runs/lamino_demo.nxs \
+--algo fbp \
+--filter ramp \
+--views-per-batch auto \
+--out runs/lamino_demo_fbp.nxs
 ```
 
-The result is stored under `/entry/processing/tomojax/volume`. Use tools such
-as `scripts/volume_slice.py` or your favourite viewer to inspect the slices.
-
-## 4. TV-Regularised FISTA Reconstruction
-
-```bash
-pixi run python -m tomojax.cli.recon \
-  --data runs/lamino_demo.nxs \
-  --algo fista \
-  --iters 75 \
-  --lambda-tv 1e-3 \
-  --tv-prox-iters 20 \
-  --views-per-batch auto \
-  --projector-unroll 2 \
-  --out runs/lamino_demo_fista.nxs
-```
-
-Monitor the log output for the FISTA loss curve. If you are memory-limited,
-reduce `views-per-batch`, disable checkpointing, or switch to `gather-dtype
-bf16/fp16`.
-
-## 5. Optional: Misalignment Stress Test
-
+## Create misaligned dataset
 ```bash
 pixi run misalign \
   --data runs/lamino_demo.nxs \
   --out runs/lamino_demo_misaligned.nxs \
-  --rot-deg 0.5 \
-  --trans-px 4 \
-  --seed 11
-
-pixi run align \
-  --data runs/lamino_demo_misaligned.nxs \
-  --outer-iters 4 --recon-iters 20 \
-  --lambda-tv 5e-3 --tv-prox-iters 15 \
-  --opt-method gn --gn-damping 1e-3 \
-  --views-per-batch auto \
-  --out runs/lamino_demo_aligned.nxs
+  --rot-deg 5.0 --trans-px 10 \
+  --seed 0 \
+  --progress
 ```
 
-The alignment CLI automatically honours the stored laminography tilt. Compare
-`/entry/processing/tomojax/align/thetas` before/after to quantify alignment
-improvements.
+## Create misaligend noisy dataset
+```bash
+pixi run misalign \
+  --data runs/lamino_demo.nxs \
+  --out runs/lamino_demo_misaligned_noisy.nxs \
+  --rot-deg 5.0 --trans-px 10 \
+  --seed 0 \
+  --poisson 10 \
+  --progress
+```
 
-## 6. Tips & Next Steps
+## Naive FBP reconstruction misaligned dataset
+```bash
+pixi run python -m tomojax.cli.recon \
+  --data runs/lamino_demo_misaligned.nxs \
+  --algo fbp \
+  --filter ramp \
+  --views-per-batch auto \
+  --out runs/lamino_demo_misaligned_fbp.nxs
+```
 
-- For analytic benchmarking, keep the voxel spacing isotropic and the detector
-  sampling identical along the thin axis to avoid anisotropic discretisation
-  artefacts.
-- If you plan to extend this tutorial (e.g. multiresolution alignment or
-  custom phantoms), copy the commands above and adjust only the relevant
-  parameters.
-- Contributions welcome: open an issue with feedback or ideas for additional
-  laminography examples.
+## Naive FBP reconstruction misaligned noisy dataset
+```bash
+pixi run python -m tomojax.cli.recon \
+  --data runs/lamino_demo_misaligned_noisy.nxs \
+  --algo fbp \
+  --filter ramp \
+  --views-per-batch auto \
+  --out runs/lamino_demo_misaligned_noisy_fbp.nxs
+```
 
----
+## Align and reconstruct misaligned dataset
+```bash
+pixi run align \
+  --data runs/lamino_demo_misaligned.nxs \
+  --outer-iters 4 --recon-iters 10 \
+  --lambda-tv 5e-3 --tv-prox-iters 10 \
+  --opt-method gn --gn-damping 1e-3 \
+  --views-per-batch auto \
+  --out runs/lamino_demo_aligned.nxs \
+  --progress --log-summary
+```
 
-*Last updated:* WIP — expect changes as laminography support evolves.
+## Align and reconstruct misaligned noisy dataset
+```bash
+pixi run align \
+  --data runs/lamino_demo_misaligned_noisy.nxs \
+  --outer-iters 4 --recon-iters 20 \
+  --lambda-tv 5e-2 --tv-prox-iters 15 \
+  --opt-method gn --gn-damping 1e-3 \
+  --views-per-batch auto \
+  --out runs/lamino_demo_noisy_aligned.nxs \
+  --progress --log-summary
+```
+
+Tips
+- Reconstructions are saved in the sample frame; use consistent axis order when viewing.
+- For memory-constrained runs, use --views-per-batch auto and keep projector checkpointing enabled.

--- a/src/tomojax/align/pipeline.py
+++ b/src/tomojax/align/pipeline.py
@@ -104,6 +104,9 @@ def align(
 
     def align_loss(params5, vol):
         # Compose augmented poses
+        # Current convention: per-view misalignment parameters act in the object
+        # frame and are post-multiplied: T_world_from_obj_aug = T_nom @ T_delta.
+        # This is consistent across parallel CT and laminography sample-frame.
         T_aug = T_nom_all @ jax.vmap(se3_from_5d)(params5)  # (n_views, 4, 4)
         n = params5.shape[0]
         b = int(cfg.views_per_batch) if int(cfg.views_per_batch) > 0 else n

--- a/src/tomojax/cli/align.py
+++ b/src/tomojax/cli/align.py
@@ -133,8 +133,10 @@ def main() -> None:
         grid=meta.get("grid"),
         detector=meta.get("detector"),
         geometry_type=meta.get("geometry_type", "parallel"),
+        geometry_meta=meta.get("geometry_meta"),
         volume=np.asarray(x),
         align_params=np.asarray(params5),
+        frame=str(meta.get("frame", "sample")),
     )
     logging.info("Saved alignment results to %s", args.out)
 

--- a/src/tomojax/cli/misalign.py
+++ b/src/tomojax/cli/misalign.py
@@ -89,8 +89,10 @@ def main() -> None:
         grid=grid.to_dict(),
         detector=det.to_dict(),
         geometry_type=geom_type,
+        geometry_meta=meta.get("geometry_meta"),
         volume=np.asarray(vol),
         align_params=np.asarray(params5),
+        frame=str(meta.get("frame", "sample")),
     )
     logging.info("Wrote dataset: %s", args.out)
 

--- a/src/tomojax/cli/recon.py
+++ b/src/tomojax/cli/recon.py
@@ -107,6 +107,7 @@ def main() -> None:
         grid=meta.get("grid"),
         detector=meta.get("detector"),
         geometry_type=meta.get("geometry_type", "parallel"),
+        geometry_meta=meta.get("geometry_meta"),
         volume=np.asarray(vol),
     )
     logging.info("Saved reconstruction to %s", args.out)

--- a/src/tomojax/cli/recon.py
+++ b/src/tomojax/cli/recon.py
@@ -43,6 +43,12 @@ def main() -> None:
     ck.add_argument("--no-checkpoint-projector", dest="checkpoint_projector", action="store_false", help="Disable projector checkpointing")
     p.set_defaults(checkpoint_projector=True)
     p.add_argument("--out", required=True, help="Output .nxs containing recon (and copying projections)")
+    p.add_argument(
+        "--frame",
+        choices=["sample", "lab"],
+        default="sample",
+        help="Frame to record for saved volume (default: sample).",
+    )
     p.add_argument("--progress", action="store_true", help="Show progress bars if tqdm is available")
     args = p.parse_args()
 
@@ -100,6 +106,9 @@ def main() -> None:
             tv_prox_iters=int(args.tv_prox_iters),
         )
 
+    # Note: Reconstructions are computed on the object (sample) frame. We persist that by default.
+    # If a lab-frame export is desired, we currently only record metadata; a resampling export
+    # may be added later if needed for interop.
     save_nxtomo(
         args.out,
         projections=np.asarray(proj),
@@ -109,6 +118,7 @@ def main() -> None:
         geometry_type=meta.get("geometry_type", "parallel"),
         geometry_meta=meta.get("geometry_meta"),
         volume=np.asarray(vol),
+        frame=str(args.frame),
     )
     logging.info("Saved reconstruction to %s", args.out)
 

--- a/src/tomojax/cli/simulate.py
+++ b/src/tomojax/cli/simulate.py
@@ -20,7 +20,11 @@ def main() -> None:
     p.add_argument("--geometry", choices=["parallel", "lamino"], default="parallel")
     p.add_argument("--tilt-deg", type=float, default=30.0)
     p.add_argument("--tilt-about", choices=["x", "z"], default="x")
-    p.add_argument("--phantom", choices=["shepp", "cube", "blobs", "random_shapes"], default="shepp")
+    p.add_argument(
+        "--phantom",
+        choices=["shepp", "cube", "blobs", "random_shapes", "lamino_disk"],
+        default="shepp",
+    )
     # random_shapes args
     p.add_argument("--n-cubes", type=int, default=8)
     p.add_argument("--n-spheres", type=int, default=7)
@@ -29,6 +33,12 @@ def main() -> None:
     p.add_argument("--min-value", type=float, default=0.1)
     p.add_argument("--max-value", type=float, default=1.0)
     p.add_argument("--max-rot-deg", type=float, default=180.0)
+    p.add_argument(
+        "--lamino-thickness-ratio",
+        type=float,
+        default=0.2,
+        help="Relative slab thickness (0-1) used by the lamino disk phantom",
+    )
     p.add_argument("--noise", choices=["none", "gaussian", "poisson"], default="none")
     p.add_argument("--noise-level", type=float, default=0.0)
     p.add_argument("--seed", type=int, default=0)
@@ -49,6 +59,7 @@ def main() -> None:
         min_size=args.min_size, max_size=args.max_size,
         min_value=args.min_value, max_value=args.max_value,
         max_rot_deg=args.max_rot_deg,
+        lamino_thickness_ratio=args.lamino_thickness_ratio,
     )
     out = simulate_to_file(cfg, args.out)
     logging.info("Wrote dataset: %s", out)

--- a/src/tomojax/cli/simulate.py
+++ b/src/tomojax/cli/simulate.py
@@ -17,6 +17,12 @@ def main() -> None:
     p.add_argument("--nu", type=int, required=True)
     p.add_argument("--nv", type=int, required=True)
     p.add_argument("--n-views", type=int, required=True)
+    p.add_argument(
+        "--rotation-deg",
+        type=float,
+        default=None,
+        help="Total rotation range in degrees. Defaults: 180 for parallel, 360 for lamino.",
+    )
     p.add_argument("--geometry", choices=["parallel", "lamino"], default="parallel")
     p.add_argument("--tilt-deg", type=float, default=30.0)
     p.add_argument("--tilt-about", choices=["x", "z"], default="x")
@@ -54,6 +60,7 @@ def main() -> None:
         nx=args.nx, ny=args.ny, nz=args.nz,
         nu=args.nu, nv=args.nv, n_views=args.n_views,
         geometry=args.geometry, tilt_deg=args.tilt_deg, tilt_about=args.tilt_about,
+        rotation_deg=(float(args.rotation_deg) if args.rotation_deg is not None else None),
         phantom=args.phantom, noise=args.noise, noise_level=args.noise_level, seed=args.seed,
         n_cubes=args.n_cubes, n_spheres=args.n_spheres,
         min_size=args.min_size, max_size=args.max_size,

--- a/src/tomojax/core/geometry/base.py
+++ b/src/tomojax/core/geometry/base.py
@@ -59,10 +59,12 @@ class Geometry(Protocol):
     """Common interface for CT, laminography, and custom geometries.
 
     Implementations describe per-view pose and per-pixel rays.
+    Contract: pose_for_view(i) returns a 4x4 world_from_object transform suitable
+    for the projector; rays_for_view(i) must define world-frame rays.
     """
 
     def pose_for_view(self, i: int) -> Tuple[Tuple[float, ...], ...]:
-        """Returns a 4x4 homogeneous transform (row-major) for view i."""
+        """Returns a 4x4 homogeneous transform world_from_object (row-major)."""
 
     def rays_for_view(self, i: int) -> Tuple[
         Callable[[int, int], Tuple[float, float, float]],

--- a/src/tomojax/core/geometry/parallel.py
+++ b/src/tomojax/core/geometry/parallel.py
@@ -15,6 +15,7 @@ class ParallelGeometry:
 
     - World frame: detector lies in (x,z) plane; rays along +y.
     - Object pose per view is rotation around +z by angle phi (radians).
+      pose_for_view returns T_world_from_obj = Rz(phi). At theta=0, T = I.
     """
 
     grid: Grid

--- a/src/tomojax/data/simulate.py
+++ b/src/tomojax/data/simulate.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Optional, Sequence
+from typing import Dict
 
 import numpy as np
 import jax.numpy as jnp
@@ -9,7 +9,7 @@ import jax.numpy as jnp
 from ..core.geometry import Grid, Detector, ParallelGeometry, LaminographyGeometry
 from ..core.projector import forward_project_view
 from ..utils.logging import progress_iter
-from .phantoms import cube, blobs, shepp_logan_3d, random_cubes_spheres
+from .phantoms import cube, blobs, shepp_logan_3d, random_cubes_spheres, lamino_disk
 from .io_hdf5 import save_nxtomo
 
 
@@ -41,6 +41,7 @@ class SimConfig:
     noise: str = "none"  # none|poisson|gaussian
     noise_level: float = 0.0  # gaussian sigma or poisson scale
     seed: int = 0
+    lamino_thickness_ratio: float = 0.2
 
 
 def make_phantom(cfg: SimConfig) -> jnp.ndarray:
@@ -59,6 +60,21 @@ def make_phantom(cfg: SimConfig) -> jnp.ndarray:
             max_rot_degrees=cfg.max_rot_deg,
             use_inscribed_fov=True, seed=cfg.seed,
         )
+    elif cfg.phantom == "lamino_disk":
+        vol = lamino_disk(
+            cfg.nx, cfg.ny, cfg.nz,
+            thickness_ratio=cfg.lamino_thickness_ratio,
+            seed=cfg.seed,
+            n_cubes=cfg.n_cubes,
+            n_spheres=cfg.n_spheres,
+            min_size=cfg.min_size,
+            max_size=cfg.max_size,
+            min_value=cfg.min_value,
+            max_value=cfg.max_value,
+            max_rot_degrees=cfg.max_rot_deg,
+            tilt_deg=cfg.tilt_deg,
+            tilt_about=cfg.tilt_about,
+        )
     else:
         raise ValueError(f"unknown phantom {cfg.phantom}")
     return jnp.asarray(vol, dtype=jnp.float32)
@@ -69,12 +85,14 @@ def simulate(cfg: SimConfig) -> Dict[str, object]:
     det = Detector(cfg.nu, cfg.nv, cfg.du, cfg.dv, det_center=(0.0, 0.0))
     thetas = np.linspace(0.0, 180.0, cfg.n_views, endpoint=False).astype(np.float32)
 
+    geometry_meta: Dict[str, object] | None = None
     if cfg.geometry == "parallel":
         geom = ParallelGeometry(grid=grid, detector=det, thetas_deg=thetas)
     elif cfg.geometry == "lamino":
         geom = LaminographyGeometry(
             grid=grid, detector=det, thetas_deg=thetas, tilt_deg=cfg.tilt_deg, tilt_about=cfg.tilt_about
         )
+        geometry_meta = {"tilt_deg": float(cfg.tilt_deg), "tilt_about": str(cfg.tilt_about)}
     else:
         raise ValueError("geometry must be 'parallel' or 'lamino'")
 
@@ -102,6 +120,7 @@ def simulate(cfg: SimConfig) -> Dict[str, object]:
         "detector": det.to_dict(),
         "geometry_type": cfg.geometry,
         "volume": vol,
+        "geometry_meta": geometry_meta,
         "meta": {"seed": cfg.seed, "noise": cfg.noise, "noise_level": cfg.noise_level},
     }
 
@@ -115,6 +134,7 @@ def simulate_to_file(cfg: SimConfig, out_path: str) -> str:
         grid=data["grid"],
         detector=data["detector"],
         geometry_type=data["geometry_type"],
+        geometry_meta=data.get("geometry_meta"),
         volume=np.asarray(data["volume"]),
     )
     return out_path

--- a/src/tomojax/utils/logging.py
+++ b/src/tomojax/utils/logging.py
@@ -38,7 +38,8 @@ def progress_iter(iterable: Iterable, *, total: Optional[int] = None, desc: str 
     try:
         from tqdm import tqdm  # type: ignore
 
-        for x in tqdm(iterable, total=total, desc=desc, dynamic_ncols=True, leave=False):
+        leave = os.environ.get("TOMOJAX_PROGRESS_LEAVE", "0").lower() in ("1","true","yes","on")
+        for x in tqdm(iterable, total=total, desc=desc, dynamic_ncols=True, leave=leave):
             yield x
     except Exception:
         # Lightweight fallback: print at ~10% increments

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -73,7 +73,8 @@ def test_lamino_axis_tilt_and_pose():
     else:
         k = np.cross(u, v); s = np.linalg.norm(k); k = k / s
         K = np.array([[0,-k[2],k[1]],[k[2],0,-k[0]],[-k[1],k[0],0]],float)
-        S = np.eye(3) + K + (1-c)/(s*s) * (K @ K)
+        # Proper Rodrigues formula for aligning u->v
+        S = np.eye(3) + s * K + (1 - c) * (K @ K)
     Ry = rot_axis_angle(ey, theta)[:3, :3]
     R_ref = S @ Ry
     assert np.allclose(T1[:3, :3], R_ref, atol=1e-7)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -8,7 +8,9 @@ from tomojax.core.geometry import (
     ParallelGeometry,
     LaminographyGeometry,
 )
-from tomojax.core.geometry.transforms import rotz, exp_se3, invert, compose
+from tomojax.core.geometry.lamino import laminography_tilt_matrix
+from tomojax.core.geometry.transforms import rotz, rot_axis_angle, exp_se3, invert, compose
+import numpy as np
 
 
 if sys.version_info < (3, 8):
@@ -46,10 +48,35 @@ def test_lamino_axis_tilt_and_pose():
     det = Detector(nu=4, nv=4, du=1.0, dv=1.0)
     geom = LaminographyGeometry(grid=grid, detector=det, thetas_deg=[0.0, 10.0], tilt_deg=30.0, tilt_about="x")
 
+    ax = geom._axis_unit()
+    exp_ax = np.array([0.0, np.sin(np.deg2rad(30.0)), np.cos(np.deg2rad(30.0))])
+    assert np.allclose(ax, exp_ax, atol=1e-7)
+
     T0 = np.array(geom.pose_for_view(0))
-    assert np.allclose(T0, np.eye(4), atol=1e-7)
+    # At theta=0 the pose equals the fixed alignment S that maps e_y to axis
+    ey = np.array([0.0, 1.0, 0.0, 1.0])
+    t0_ey = T0 @ ey
+    assert np.allclose(t0_ey[:3], ax, atol=1e-6)
 
     T1 = np.array(geom.pose_for_view(1))
+    # In sample-frame parametrization: R = S @ R_y(theta), S aligns e_y -> axis
+    ey = np.array([0.0, 1.0, 0.0])
+    theta = np.deg2rad(10.0)
+    # Build S by aligning e_y to axis via cross-product formula
+    u = ey / np.linalg.norm(ey)
+    v = ax / np.linalg.norm(ax)
+    c = np.dot(u, v)
+    if c > 1.0 - 1e-12:
+        S = np.eye(3)
+    elif c < -1.0 + 1e-12:
+        S = np.diag([1.0, -1.0, -1.0])
+    else:
+        k = np.cross(u, v); s = np.linalg.norm(k); k = k / s
+        K = np.array([[0,-k[2],k[1]],[k[2],0,-k[0]],[-k[1],k[0],0]],float)
+        S = np.eye(3) + K + (1-c)/(s*s) * (K @ K)
+    Ry = rot_axis_angle(ey, theta)[:3, :3]
+    R_ref = S @ Ry
+    assert np.allclose(T1[:3, :3], R_ref, atol=1e-7)
     # Rotation angle should be 10 deg around some axis; check orthonormality
     R = T1[:3, :3]
     assert np.allclose(np.dot(R.T, R), np.eye(3), atol=1e-6)

--- a/tests/test_phantoms.py
+++ b/tests/test_phantoms.py
@@ -1,13 +1,11 @@
 import numpy as np
 
 from tomojax.data.phantoms import lamino_disk
-from tomojax.core.geometry.lamino import laminography_axis_unit
 
 
 def test_lamino_disk_thickness_centered():
     nx, ny, nz = 32, 64, 32
     ratio = 0.2
-    tilt_deg = 35.0
     vol = lamino_disk(
         nx,
         ny,
@@ -16,20 +14,15 @@ def test_lamino_disk_thickness_centered():
         seed=0,
         min_size=4,
         max_size=12,
-        tilt_deg=tilt_deg,
-        tilt_about="x",
     )
 
     assert vol.shape == (nx, ny, nz)
     assert np.isclose(vol.max(), 1.0, atol=1e-6)
 
-    axis = laminography_axis_unit(tilt_deg, "x").astype(np.float32)
-    coords = np.argwhere(vol > 1e-4).astype(np.float32)
-    assert coords.size > 0
-
-    center = np.array([(nx - 1) / 2.0, (ny - 1) / 2.0, (nz - 1) / 2.0], dtype=np.float32)
-    rel = coords - center
-    dist = rel @ axis
+    # In sample frame, slab is orthogonal to +y, confined to central y slices
+    ys = np.argwhere(vol.max(axis=(0,2)) > 1e-4).ravel()
+    assert ys.size > 0
+    cy = (ny - 1) / 2.0
+    dist = np.abs(ys - cy)
     expected = max(1, int(round(ratio * ny))) * 0.5 + 0.75
     assert dist.max() <= expected
-    assert dist.min() >= -expected

--- a/tests/test_phantoms.py
+++ b/tests/test_phantoms.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+from tomojax.data.phantoms import lamino_disk
+from tomojax.core.geometry.lamino import laminography_axis_unit
+
+
+def test_lamino_disk_thickness_centered():
+    nx, ny, nz = 32, 64, 32
+    ratio = 0.2
+    tilt_deg = 35.0
+    vol = lamino_disk(
+        nx,
+        ny,
+        nz,
+        thickness_ratio=ratio,
+        seed=0,
+        min_size=4,
+        max_size=12,
+        tilt_deg=tilt_deg,
+        tilt_about="x",
+    )
+
+    assert vol.shape == (nx, ny, nz)
+    assert np.isclose(vol.max(), 1.0, atol=1e-6)
+
+    axis = laminography_axis_unit(tilt_deg, "x").astype(np.float32)
+    coords = np.argwhere(vol > 1e-4).astype(np.float32)
+    assert coords.size > 0
+
+    center = np.array([(nx - 1) / 2.0, (ny - 1) / 2.0, (nz - 1) / 2.0], dtype=np.float32)
+    rel = coords - center
+    dist = rel @ axis
+    expected = max(1, int(round(ratio * ny))) * 0.5 + 0.75
+    assert dist.max() <= expected
+    assert dist.min() >= -expected


### PR DESCRIPTION
### Summary

* Adopt sample (object) frame as the default for recon outputs (`FBP`, `FISTA`).
* Fix laminography phantom: thin slab is now orthogonal to the sample rotation axis (`+y`), not the world tilt axis.
* Add `simulate --rotation-deg` with sensible defaults:
    * `parallel`: 180°
    * `lamino`: 360°
* Add `recon --frame` to record the saved volume frame; persist the frame in NXtomo.

---

### Details

**Geometry/Projector conventions**
* Standardize `pose_for_view(i)` → `T_world_from_object` (sample frame).
* The projector builds world rays and samples in object coordinates via `inv(T)`.
* Documented invariants in geometry/projector modules.

**Laminography**
* `LaminographyGeometry` returns `S @ R_y(theta)` (where `S` maps `e_y` → tilted axis).
* `lamino_disk` phantom: objects are constrained to central y-slices in the object frame (sample frame), ensuring lamino behavior across views.

**CLI/IO**
* `simulate`: new `--rotation-deg`; default is 360° for `lamino` and 180° for `parallel`.
* `recon`: new `--frame {sample,lab}` (default: `sample`). The volume frame is persisted under `/entry/processing/tomojax@frame`.
* `misalign`/`align` CLIs preserve `geometry_meta` and `frame` in outputs.
* Progress: allow persistent `tqdm` bars via `TOMOJAX_PROGRESS_LEAVE=1`.

**Docs**
* New laminography tutorial is now end-to-end: `simulate` → `FBP` → `misalign` → noisy → naive `FBP` → `align` (with `--progress --log-summary`).
* CLI reference updated for `--rotation-deg` and `--frame`.
* README: new laminography feature section, sample commands, and a tutorial link.
* Schema: `geometry_meta_json` (`tilt_deg`, `tilt_about`) and `tomojax@frame`; clarify volume shape (`nx, ny, nz`).
* FAQ: laminography specifics (orientation in sample frame, 360° rationale, progress tips).

**Tests**
* Correct Rodrigues alignment in the lamino geometry test.
* Update lamino phantom thickness test for the sample-frame slab.
* Lamino `FBP` integration passes; the overall suite is OK on CPU.

---

### Rationale

* Users expect laminography reconstructions to be aligned with the rotation axis in the sample frame to see the full thin slab per slice.
* 360° coverage is standard for parallel-beam laminography.

---

### Verification

* `Simulate lamino (tilt 35°, 360°, thin slab)` → `FBP` recon shows expected slab thickness across views; sample-frame slices align with the rotation axis.
* `test_integration_lamino_fbp_psnr_from_sim` passes on CPU.
* The full test suite passes locally except for environment-related GPU init quirks; CPU runs are stable.

---

### Notes and follow-ups

* If desired, we can add a resampling export to save lab-frame arrays, and/or scripts to verify/view the sample-frame orientation.
* Alignment composition currently uses `T_aug = T_nom @ se3_from_5d(params)`; this is consistent across parallel CT and laminography with the sample-frame convention. Further global-tilt refinement could be added later.

---

### Changelog

* **feat**: laminography sample-frame output, rotation span flag, CLI frame metadata
* **fix**: lamino phantom slab orientation; Rodrigues alignment in test
* **docs**: laminography tutorial + CLI updates; schema/FAQ clarifications