### PR TITLE
feat(align,fista): reduce XLA compiles and stabilize memory; fix scan body

### DIFF
--- a/src/tomojax/align/pipeline.py
+++ b/src/tomojax/align/pipeline.py
@@ -117,6 +117,7 @@ def align(
         nv = int(projections.shape[1])
         nu = int(projections.shape[2])
         b = int(cfg.views_per_batch) if int(cfg.views_per_batch) > 0 else n
+        b = min(b, n)
         m = (n + b - 1) // b
 
         def body(loss_acc, i):

--- a/src/tomojax/align/pipeline.py
+++ b/src/tomojax/align/pipeline.py
@@ -136,7 +136,7 @@ def align(
             return (loss_acc + loss_batch, None)
 
         loss0 = jnp.float32(0.0)
-        loss_tot, _ = jax.lax.scan(body, loss0, None, length=m)
+        loss_tot, _ = jax.lax.scan(body, loss0, jnp.arange(m))
 
         # Smoothness prior across views (2nd difference)
         loss = loss_tot

--- a/src/tomojax/align/pipeline.py
+++ b/src/tomojax/align/pipeline.py
@@ -112,31 +112,31 @@ def align(
         # frame and are post-multiplied: T_world_from_obj_aug = T_nom @ T_delta.
         # This is consistent across parallel CT and laminography sample-frame.
         T_aug = T_nom_all @ jax.vmap(se3_from_5d)(params5)  # (n_views, 4, 4)
-        n = jnp.int32(params5.shape[0])
-        b_py = int(cfg.views_per_batch) if int(cfg.views_per_batch) > 0 else int(n)
-        b = jnp.int32(b_py)
-
-        # Prepare padded arrays to get a uniform chunk size
-        m = jnp.int32((n + b - 1) // b)
-        pad = jnp.int32(m * b - n)
-        T_pad = jnp.pad(T_aug, ((0, pad), (0, 0), (0, 0)))
-        y_pad = jnp.pad(projections, ((0, pad), (0, 0), (0, 0)))
+        # Use Python ints for sizes to keep them static
+        n = int(params5.shape[0])
+        nv = int(projections.shape[1])
+        nu = int(projections.shape[2])
+        b = int(cfg.views_per_batch) if int(cfg.views_per_batch) > 0 else n
+        m = (n + b - 1) // b
 
         def body(loss_acc, i):
             i = jnp.int32(i)
-            start = i * b
-            T_chunk = jax.lax.dynamic_slice(T_pad, (start, 0, 0), (b, 4, 4))
-            y_chunk = jax.lax.dynamic_slice(y_pad, (start, 0, 0), (b, projections.shape[1], projections.shape[2]))
+            start = i * jnp.int32(b)
+            remaining = jnp.maximum(0, jnp.int32(n) - start)
+            valid = jnp.minimum(jnp.int32(b), remaining)
+            shift = jnp.int32(b) - valid
+            start_shifted = jnp.maximum(0, start - shift)
+            T_chunk = jax.lax.dynamic_slice(T_aug, (start_shifted, 0, 0), (b, 4, 4))
+            y_chunk = jax.lax.dynamic_slice(projections, (start_shifted, 0, 0), (b, nv, nu))
             pred = _project_batch(T_chunk, vol)
-            remaining = jnp.maximum(0, n - start)
-            valid = jnp.minimum(b, remaining)
-            mask = (jnp.arange(b) < valid)[:, None, None]
+            idx = jnp.arange(b)
+            mask = (idx >= (jnp.int32(b) - valid))[:, None, None]
             resid = (pred - y_chunk).astype(jnp.float32) * mask
             loss_batch = 0.5 * jnp.vdot(resid, resid).real
             return (loss_acc + loss_batch, None)
 
         loss0 = jnp.float32(0.0)
-        loss_tot, _ = jax.lax.scan(body, loss0, jnp.arange(m))
+        loss_tot, _ = jax.lax.scan(body, loss0, None, length=m)
 
         # Smoothness prior across views (2nd difference)
         loss = loss_tot

--- a/src/tomojax/recon/fista_tv.py
+++ b/src/tomojax/recon/fista_tv.py
@@ -106,7 +106,7 @@ def grad_data_term(
             return (loss_acc + loss_batch, None)
 
         loss0 = jnp.float32(0.0)
-        loss_tot, _ = jax.lax.scan(body, loss0, None, length=m)
+        loss_tot, _ = jax.lax.scan(body, loss0, jnp.arange(m))
         return loss_tot
 
     def stream_loss_and_grad(vol):

--- a/src/tomojax/recon/fista_tv.py
+++ b/src/tomojax/recon/fista_tv.py
@@ -84,6 +84,7 @@ def grad_data_term(
         nv = int(projections.shape[1])
         nu = int(projections.shape[2])
         b = int(views_per_batch) if (views_per_batch is not None and int(views_per_batch) > 0) else n
+        b = min(b, n)
         m = (n + b - 1) // b
 
         def body(loss_acc, i):


### PR DESCRIPTION
Summary
This PR improves stability and performance of alignment and FISTA by:

- Replacing Python chunk loops with a single lax.scan plus dynamic_slice and masked
tails to keep a single compiled jaxpr per batch size/resolution.
- Avoiding jnp.pad with traced pad widths; uses end-aligned masking with static-length
scans instead.
- Ensuring scan bodies receive explicit xs (fixes None input to scan).
- Laying groundwork for lower-compilation FISTA power-method selection.

Changes

- align/pipeline.py
    - Align loss over views now uses lax.scan + dynamic_slice with masked tails.
    - Minor logging tidy-ups for step metrics.
- recon/fista_tv.py
    - Batched data-term uses lax.scan + dynamic_slice and a single vmap body.
    - Power-method mode can be chosen based on views_per_batch (stream vs batched).
- utils/memory.py
    - No changes in this reset (only earlier commits touched).

Why

- Reduces repeated XLA compilations caused by Python loops over variable-sized chunks.
- Stabilizes memory by avoiding pad with traced sizes and using masked tails instead.
- Keeps a single, smaller jaxpr for both reconstruction and alignment passes,
improving cache reuse and build times.

Reproduction
CPU-friendly smoke tests (from pixi shell):

- pixi run install-root
- pixi run python -m pytest -q tests/test_projector.py
- pixi run python -m pytest -q tests/test_fista_tv.py
- pixi run python -m pytest -q tests/test_align.py

CLI checks:

- pixi run simulate --help
- pixi run recon --data data/sim.nxs --algo fbp --views-per-batch auto --out runs/
fbp.nxs
- pixi run recon --data data/sim.nxs --algo fista-tv --views-per-batch 1 --out runs/
fista.nxs
- pixi run align --data data/sim.nxs --levels 2 1 --outer-iters 3 --out runs/align.nxs

Performance Notes

- Device: CPU or small GPU is fine for verification; benefits on GPU are primarily
fewer compiles and more stable memory footprint for batched paths.
- Shapes: Use tests’ defaults for quick checks.
- Expect smaller jaxprs and fewer recompilations after the first run when
views_per_batch is fixed.

Compatibility

- No API breaks; only internal implementation changes.
- AlignConfig and FISTA signatures unchanged.
