### PR TITLE
chore(cli): default to streamed projector settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 - Run tests: `pixi run test` or target a file, e.g., `pixi run python -m pytest -q tests/test_projector.py`.
 - CLI workflows (examples; see `README.md` for more):
   - Simulate: `pixi run simulate --help`
-  - Recon: `pixi run recon --data data/sim.nxs --algo fbp --views-per-batch auto --out runs/fbp.nxs`
+  - Recon: `pixi run recon --data data/sim.nxs --algo fbp --out runs/fbp.nxs`
   - Align: `pixi run align --data data/sim_misaligned.nxs --levels 2 1 --outer-iters 4 --out runs/align.nxs`
 
 ## Coding Style & Naming Conventions

--- a/README.md
+++ b/README.md
@@ -111,14 +111,14 @@ pixi run misalign --data data/sim_aligned.nxs --out data/sim_misaligned_poisson5
 
 # Naive reconstructions (FBP)
 pixi run recon --data data/sim_misaligned.nxs \
-  --algo fbp --filter ramp --views-per-batch auto --gather-dtype bf16 \
+  --algo fbp --filter ramp --gather-dtype bf16 \
   --checkpoint-projector --out out/fbp_misaligned.nxs
 
 # Iterative alignment + reconstruction (multires)
 pixi run align --data data/sim_misaligned.nxs \
   --levels 4 2 1 --outer-iters 4 --recon-iters 25 --lambda-tv 0.003 \
   --opt-method gn --gn-damping 1e-3 \
-  --views-per-batch auto --gather-dtype bf16 --checkpoint-projector --projector-unroll 4 \
+  --gather-dtype bf16 --checkpoint-projector \
   --log-summary --out out/align_misaligned.nxs
 ```
 
@@ -173,8 +173,6 @@ See `docs/schema_nxtomo.md` for the HDF5/NXtomo format used by the CLIs.
 
 ## Memory and Performance
 
-- Use `--views-per-batch auto` to automatically choose a safe batch size; set `TOMOJAX_MAX_VIEWS_PER_BATCH` to clamp the auto choice (default 8).
-- Reduce `--projector-unroll` (1–2) when close to memory limits.
 - Keep `--checkpoint-projector` enabled to reduce activation memory at small extra compute.
 - Mixed precision gather (`--gather-dtype bf16`) reduces bandwidth while accumulating in fp32.
 - To avoid JAX preallocation spikes: `export XLA_PYTHON_CLIENT_PREALLOCATE=false`.

--- a/docs/faq_troubleshooting.md
+++ b/docs/faq_troubleshooting.md
@@ -14,15 +14,12 @@
 ## Memory / OOM
 
 - Out of memory (RESOURCE_EXHAUSTED) during FBP or FISTA:
-  - Use `--views-per-batch auto` (recommended) or a small integer (e.g., 4 or 8).
-  - Reduce `--projector-unroll` to 1–2.
   - Keep `--checkpoint-projector` enabled.
   - Prefer `--gather-dtype bf16` on newer GPUs.
   - Disable JAX preallocation: `export XLA_PYTHON_CLIENT_PREALLOCATE=false`.
+  - Reduce problem size (coarser levels, fewer views) if needed.
 
-- Auto batch seems too large:
-  - Clamp with `export TOMOJAX_MAX_VIEWS_PER_BATCH=4`.
-  - For very large volumes (≥256³), expect conservative caps by design.
+\
 
 
 ## Alignment Convergence

--- a/docs/tutorial_laminography.md
+++ b/docs/tutorial_laminography.md
@@ -31,7 +31,6 @@ pixi run python -m tomojax.cli.recon \
 --data runs/lamino_demo.nxs \
 --algo fbp \
 --filter ramp \
---views-per-batch auto \
 --out runs/lamino_demo_fbp.nxs
 ```
 
@@ -62,7 +61,6 @@ pixi run python -m tomojax.cli.recon \
   --data runs/lamino_demo_misaligned.nxs \
   --algo fbp \
   --filter ramp \
-  --views-per-batch auto \
   --out runs/lamino_demo_misaligned_fbp.nxs
 ```
 
@@ -72,7 +70,6 @@ pixi run python -m tomojax.cli.recon \
   --data runs/lamino_demo_misaligned_noisy.nxs \
   --algo fbp \
   --filter ramp \
-  --views-per-batch auto \
   --out runs/lamino_demo_misaligned_noisy_fbp.nxs
 ```
 
@@ -83,7 +80,6 @@ pixi run align \
   --outer-iters 4 --recon-iters 10 \
   --lambda-tv 5e-3 --tv-prox-iters 10 \
   --opt-method gn --gn-damping 1e-3 \
-  --views-per-batch auto \
   --out runs/lamino_demo_aligned.nxs \
   --progress --log-summary
 ```
@@ -95,11 +91,10 @@ pixi run align \
   --outer-iters 4 --recon-iters 20 \
   --lambda-tv 5e-2 --tv-prox-iters 15 \
   --opt-method gn --gn-damping 1e-3 \
-  --views-per-batch auto \
   --out runs/lamino_demo_noisy_aligned.nxs \
   --progress --log-summary
 ```
 
 Tips
 - Reconstructions are saved in the sample frame; use consistent axis order when viewing.
-- For memory-constrained runs, use --views-per-batch auto and keep projector checkpointing enabled.
+- For memory-constrained runs, keep projector checkpointing enabled.

--- a/scripts/perf_harness.py
+++ b/scripts/perf_harness.py
@@ -41,19 +41,17 @@ def main() -> None:
     outdir.mkdir(parents=True, exist_ok=True)
 
     combos = []
-    vpbs = ["0", "8", "16", "auto"]
     dtypes = ["fp32", "bf16"]
     ckpts = [True, False]
 
     for algo in args.modes:
-        for vpb in vpbs:
-            for dt in dtypes:
-                for ck in ckpts:
-                    combos.append((algo, vpb, dt, ck))
+        for dt in dtypes:
+            for ck in ckpts:
+                combos.append((algo, dt, ck))
 
     results = []
-    for algo, vpb, dt, ck in combos:
-        out = outdir / f"{algo}_vpb{vpb}_{dt}_{'ck' if ck else 'nock'}.nxs"
+    for algo, dt, ck in combos:
+        out = outdir / f"{algo}_{dt}_{'ck' if ck else 'nock'}.nxs"
         if algo == "fbp":
             cmd = [
                 "python",
@@ -65,8 +63,6 @@ def main() -> None:
                 "fbp",
                 "--filter",
                 "ramp",
-                "--views-per-batch",
-                str(vpb),
                 "--gather-dtype",
                 dt,
                 ("--checkpoint-projector" if ck else "--no-checkpoint-projector"),
@@ -86,8 +82,6 @@ def main() -> None:
                 "20",
                 "--lambda-tv",
                 "0.001",
-                "--views-per-batch",
-                str(vpb),
                 "--gather-dtype",
                 dt,
                 ("--checkpoint-projector" if ck else "--no-checkpoint-projector"),
@@ -97,7 +91,6 @@ def main() -> None:
         res = run(cmd)
         results.append({
             "algo": algo,
-            "views_per_batch": vpb,
             "gather_dtype": dt,
             "checkpoint": ck,
             **res,
@@ -107,7 +100,7 @@ def main() -> None:
         json.dump(results, f, indent=2)
     # Print concise table to stdout
     rows = [
-        f"{r['algo']:5s} vpb={str(r['views_per_batch']):>4s} dt={r['gather_dtype']:5s} ck={str(r['checkpoint']):5s} t={r['secs']:7.3f}s rc={r['rc']}"
+        f"{r['algo']:5s} dt={r['gather_dtype']:5s} ck={str(r['checkpoint']):5s} t={r['secs']:7.3f}s rc={r['rc']}"
         for r in results
     ]
     print("\n".join(rows))
@@ -115,4 +108,3 @@ def main() -> None:
 
 if __name__ == "__main__":  # pragma: no cover
     main()
-

--- a/src/tomojax/align/pipeline.py
+++ b/src/tomojax/align/pipeline.py
@@ -28,9 +28,9 @@ class AlignConfig:
     # Alignment step sizes
     lr_rot: float = 1e-3  # radians
     lr_trans: float = 1e-1  # world units
-    # Memory/throughput knobs
-    views_per_batch: int = 0  # 0 -> all views at once
-    projector_unroll: int = 4
+    # Memory/throughput knobs (hidden defaults)
+    views_per_batch: int = 1  # stream one view at a time
+    projector_unroll: int = 1
     checkpoint_projector: bool = True
     gather_dtype: str = "fp32"
     # Solver & regularization
@@ -305,7 +305,7 @@ def align(
                     msg2 = str(e2)
                     if ("RESOURCE_EXHAUSTED" in msg2) or ("Out of memory" in msg2) or ("Allocator" in msg2):
                         logging.error(
-                            "FISTA still OOM at finest level. Suggest reducing --views-per-batch, setting --projector-unroll 1, or pinning --recon-L to skip power-method."
+                            "FISTA still OOM at finest level. Reduce memory pressure (smaller problem size or lower internal batching), or provide --recon-L to skip power-method."
                         )
                     raise
             else:

--- a/src/tomojax/cli/align.py
+++ b/src/tomojax/cli/align.py
@@ -60,8 +60,6 @@ def main() -> None:
     p.add_argument("--lr-rot", type=float, default=1e-3)
     p.add_argument("--lr-trans", type=float, default=1e-1)
     p.add_argument("--levels", type=int, nargs="+", default=None, help="Optional multires factors, e.g., 4 2 1")
-    p.add_argument("--views-per-batch", default="0", help="Batch views to control memory (0=all). Use 'auto' to estimate.")
-    p.add_argument("--projector-unroll", type=int, default=1, help="Unroll factor inside projector scan")
     p.add_argument("--gather-dtype", choices=["fp32", "bf16", "fp16"], default="fp32", help="Projector gather dtype")
     ck = p.add_mutually_exclusive_group()
     ck.add_argument("--checkpoint-projector", dest="checkpoint_projector", action="store_true")
@@ -86,20 +84,8 @@ def main() -> None:
     grid, detector, geom = build_geometry(meta)
     proj = jnp.asarray(meta["projections"], dtype=jnp.float32)
 
-    # Resolve views_per_batch (int or 'auto')
-    vpb_str = str(args.views_per_batch)
-    if vpb_str.strip().lower() == "auto":
-        from ..utils.memory import estimate_views_per_batch
-        vpb_est = estimate_views_per_batch(
-            n_views=int(proj.shape[0]),
-            grid_nxyz=(int(grid.nx), int(grid.ny), int(grid.nz)),
-            det_nuv=(int(detector.nv), int(detector.nu)),
-            gather_dtype=str(args.gather_dtype),
-            checkpoint_projector=bool(args.checkpoint_projector),
-            algo="fista",
-        )
-    else:
-        vpb_est = int(vpb_str)
+    # Hidden defaults: stream one view at a time; unroll=1
+    vpb_est = 1
 
     cfg = AlignConfig(
         outer_iters=args.outer_iters,
@@ -109,7 +95,7 @@ def main() -> None:
         lr_rot=args.lr_rot,
         lr_trans=args.lr_trans,
         views_per_batch=int(vpb_est),
-        projector_unroll=int(args.projector_unroll),
+        projector_unroll=1,
         checkpoint_projector=bool(args.checkpoint_projector),
         gather_dtype=str(args.gather_dtype),
         opt_method=str(args.opt_method),

--- a/src/tomojax/recon/fbp.py
+++ b/src/tomojax/recon/fbp.py
@@ -74,7 +74,7 @@ def fbp(
     *,
     filter_name: str = "ramp",
     scale: float | None = None,
-    views_per_batch: int = 0,
+    views_per_batch: int = 1,
     projector_unroll: int = 1,
     checkpoint_projector: bool = True,
     gather_dtype: str = "fp32",

--- a/src/tomojax/recon/fista_tv.py
+++ b/src/tomojax/recon/fista_tv.py
@@ -251,7 +251,7 @@ def fista_tv(
     L: float | None = None,
     callback: Callable[[int, float], None] | None = None,
     init_x: jnp.ndarray | None = None,
-    views_per_batch: int | None = None,
+    views_per_batch: int | None = 1,
     projector_unroll: int = 1,
     checkpoint_projector: bool = True,
     gather_dtype: str = "fp32",


### PR DESCRIPTION
## Summary
- Drop the `--views-per-batch` / `--projector-unroll` switches from the recon & align
CLIs and hard-wire their configs to the streamed projector path with unroll=1 (`src/
tomojax/cli/align.py:87`, `src/tomojax/cli/recon.py:61`).
- Make AlignConfig, FBP, and FISTA default to the same streamed settings and soften
the OOM error messaging so it points to the remaining safe levers (`src/tomojax/align/
pipeline.py:31`, `src/tomojax/recon/fbp.py:45`, `src/tomojax/recon/fista_tv.py:254`).
- Refresh docs, troubleshooting notes, the perf harness, and contributor guidance
to match the smaller knob surface (`README.md:112`, `docs/cli_reference.md:33`,
`docs/faq_troubleshooting.md:15`, `docs/tutorial_end_to_end.md:86`, `docs/
tutorial_laminography.md:25`, `scripts/perf_harness.py:43`, `AGENTS.md:22`).

## Rationale
- On the 256³ / 50 GiB runs we benchmarked, streaming (`vpb=1`, `unroll=1`) is as
fast as any larger batch after the lax.scan refactor, because the projector is memory-
bound; bigger batches either don’t pay off or trigger 48 GiB allocations and OOMs at
the finest multires level.
- Leaving the knobs exposed in the CLI mostly encourages users to pick values that
crash; we still support overrides via the Python APIs for advanced tuning, while
keeping the CLI on the safe, fastest-by-default path.
