### PR TITLE
perf(align): insert device barriers for accurate recon/align timing

### DIFF
--- a/src/tomojax/align/pipeline.py
+++ b/src/tomojax/align/pipeline.py
@@ -310,6 +310,12 @@ def align(
                     raise
             else:
                 raise
+        # Ensure device work is finished before timing recon
+        try:
+            x.block_until_ready()
+        except Exception:
+            # Fallback if x is not a DeviceArray-like object
+            jax.block_until_ready(x)
         recon_time = time.perf_counter() - recon_start
         stat["recon_time"] = recon_time
         stat["recon_retry"] = recon_retry
@@ -389,6 +395,11 @@ def align(
                 pass
         stat["step_kind"] = step_kind
         stat["loss_after_step"] = loss_after
+        # Ensure device work from alignment step is finished before timing
+        try:
+            jax.block_until_ready(params5)
+        except Exception:
+            pass
         stat["align_time"] = time.perf_counter() - align_start
 
         # Track overall data loss


### PR DESCRIPTION
This PR ensures our reported timings for reconstruction and alignment reflect actual device work completion.

Changes
- After FISTA (“Recon step”), block on the returned volume before computing `recon_time`:
  - `x.block_until_ready()` with a safe fallback to `jax.block_until_ready(x)`.
- After the alignment step, block on `params5` before computing `align_time`.

Why
- JAX executes lazily; without explicit barriers, `perf_counter` can under-report time since kernels continue running on the device.
- Adding barriers makes `recon_time` and `align_time` honest for the benchmarking runs that follow.

Scope
- File: `src/tomojax/align/pipeline.py`
- No API changes; default behavior unchanged aside from timing accuracy.

Validation
- Local smoke run confirms no behavioral changes; timings now align with device utilization as expected.

Follow-ups
- Proceed with subsequent performance upgrades (per plan) and benchmark after each change.
