### PR TITLE
perf: bf16 default, prebuilt T_all, simulate fast path

### DIFF
--- a/src/tomojax/utils/memory.py
+++ b/src/tomojax/utils/memory.py
@@ -121,3 +121,22 @@ def estimate_views_per_batch(
         cap_env = min(cap_env, 2)
     cap = max(1, cap_env)
     return max(1, min(int(n_views), cap, b))
+
+
+def default_gather_dtype() -> str:
+    """Choose a default gather dtype based on the active JAX backend.
+
+    Returns "bf16" on GPU/TPU (mixed-precision gather with fp32 accumulation)
+    and "fp32" on CPU or if backend detection fails.
+    """
+    try:
+        import jax  # type: ignore
+
+        backend = getattr(jax, "default_backend", lambda: None)()
+        if isinstance(backend, str):
+            b = backend.lower()
+            if b in ("gpu", "tpu"):
+                return "bf16"
+    except Exception:
+        pass
+    return "fp32"


### PR DESCRIPTION
Summary\n- Default mixed-precision gather on accelerators: new --gather-dtype auto, resolves to bf16 on GPU/TPU, fp32 on CPU. Accumulation remains fp32.\n- Reduce Python/JAX host work: precompute and thread T_all in FISTA (incl. power-method and val_and_grad) instead of stacking per-call.\n- Simulate fast path: vmapped+jitted projector with device-side detector grid; keep progress-loop fallback for small runs/logging.\n\nDetails\n- CLIs (align/recon): switch to auto default, still allow explicit fp32/bf16/fp16 override.\n- utils.memory: default_gather_dtype() helper.\n- recon.fista_tv: add optional T_all arg to grad_data_term/power_method_L; fista_tv builds T_all once and threads it.\n- data.simulate: prebuild T_all + det_grid; jit+vmap projector when not showing progress.\n\nRationale\n- Expect VRAM/bandwidth wins with identical numerics from bf16 gather + fp32 accumulation.\n- Prebuilt T_all removes repeated small host->device transfers and host Python overhead captured by transfer guard logs.\n- Simulate fast path speeds larger synthetic datasets while preserving existing progress behavior.\n\nValidation\n- Align/recon CLIs run as before; explicit dtype flags still honored.\n- No changes to projector math; only data movement & dtype defaults.\n- Benchmarks previously showed ~11–12% speedup from projector inner loop improvements; these changes further reduce host overhead.\n\nFollow-ups\n- Optionally prebuild and thread T_all in any remaining code paths if we add new ones.\n- Update docs to note the new auto default and simulate fast path behavior.