### PR TITLE
feat(align): CLI flags to disable/tune early stopping across outers

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ pixi run align --data data/sim_misaligned.nxs \
   --opt-method gn --gn-damping 1e-3 \
   --gather-dtype bf16 --checkpoint-projector \
   --log-summary --out out/align_misaligned.nxs
+
+# Deterministic misalignment schedules (see docs/misalign_modes.md)
+# Linear angle drift 0→+5° across the scan
+pixi run misalign --data data/sim_aligned.nxs --out runs/mis_angle_lin.nxs \
+  --pert angle:linear:delta=5deg
+# Sinusoidal dx drift peaking +5 px at mid‑scan
+pixi run misalign --data data/sim_aligned.nxs --out runs/mis_dx_sin.nxs \
+  --pert dx:sin-window:amp=5px
 ```
 
 

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -19,7 +19,7 @@ python -m tomojax.cli.simulate --out <path.nxs> \
   --nu <int> --nv <int> --n-views <int> \
   [--geometry parallel|lamino] [--tilt-deg <float>] [--tilt-about x|z] \
   [--rotation-deg <float>] \
-  [--phantom shepp|cube|blobs|random_shapes] [phantom-args...] \
+  [--phantom shepp|cube|sphere|blobs|random_shapes|lamino_disk] [phantom-args...] \
   [--noise none|gaussian|poisson] [--noise-level <float>] \
   [--seed <int>] [--progress]
 ```
@@ -27,9 +27,12 @@ python -m tomojax.cli.simulate --out <path.nxs> \
 Key options
 - Geometry: `--geometry parallel` (default) or `lamino` with `--tilt-deg` (default 30) about axis `--tilt-about` (`x` default).
 - Rotation span: `--rotation-deg` sets the total angular range. Defaults to 180 for `parallel` and 360 for `lamino`.
-- Phantom: `--phantom random_shapes` with controls:
-  - `--n-cubes` (8), `--n-spheres` (7), `--min-size` (4), `--max-size` (32)
-  - `--min-value` (0.1), `--max-value` (1.0), `--max-rot-deg` (180)
+- Phantom:
+  - Single centered object: `--phantom cube|sphere` with `--single-size` (relative fraction of min dim; side for cube, diameter for sphere) and `--single-value`. For `cube`, a random 3D rotation is applied by default; disable with `--no-single-rotate`.
+  - Random shapes: `--phantom random_shapes` with controls:
+    - `--n-cubes` (8), `--n-spheres` (7), `--min-size` (4), `--max-size` (32)
+    - `--min-value` (0.1), `--max-value` (1.0), `--max-rot-deg` (180)
+  - Laminography slab: `--phantom lamino_disk` with `--lamino-thickness-ratio` and the random_shapes knobs above.
 - Noise: `--noise gaussian --noise-level <sigma>` or `--noise poisson --noise-level <scale>`.
 
 Example

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -132,6 +132,7 @@ python -m tomojax.cli.align --data <in.nxs> \
   [--tv-prox-iters <int>] \
   [--lr-rot <float>] [--lr-trans <float>] \
   [--opt-method gd|gn] [--gn-damping <float>] \
+  [--early-stop|--no-early-stop] [--early-stop-rel <float>] [--early-stop-patience <int>] \
   [--w-rot <float>] [--w-trans <float>] [--seed-translations] \
   [--levels <ints...>] [--gather-dtype fp32|bf16|fp16] \
   [--checkpoint-projector|--no-checkpoint-projector] [--recon-L <float>] [--log-summary] \
@@ -141,6 +142,9 @@ python -m tomojax.cli.align --data <in.nxs> \
 Key options
 - Outer/inner loops: `--outer-iters` (5), `--recon-iters` (10), `--lambda-tv` (0.005), `--tv-prox-iters` (10; increase to 20–30 for noisy data).
 - Alignment step: gradient descent (`--lr-rot`, `--lr-trans`) or Gauss‑Newton (`--opt-method gn`, `--gn-damping`).
+- Early stopping (alignment across outers):
+  - Enable/disable: `--early-stop` (default) or `--no-early-stop`.
+  - Threshold and patience: `--early-stop-rel` (default 1e-3), `--early-stop-patience` (default 2).
 - Smoothness across views: `--w-rot`, `--w-trans` (default 1e‑3 in CLI).
 - Multi‑resolution: `--levels 4 2 1` for coarse→fine; optional `--seed-translations` uses phase correlation at the coarsest level.
 - Memory/performance: same knobs as recon (gather dtype and checkpointing).

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -53,6 +53,7 @@ Usage
 ```
 python -m tomojax.cli.misalign --data <in.nxs> --out <out.nxs> \
   [--rot-deg <float>] [--trans-px <float>] [--poisson <float>] \
+  [--pert dof:shape[:k=v[,k=v...]]] [--spec schedules.json] [--with-random] \
   [--seed <int>] [--progress]
 ```
 
@@ -60,6 +61,10 @@ Key options
 - `--rot-deg`: max absolute per‑view rotation in degrees for α, β, φ (default 1.0).
 - `--trans-px`: max absolute per‑view translation in detector pixels for (dx, dz) (default 10.0). Converted to world units via detector spacing.
 - `--poisson`: incident intensity scale s for Poisson noise. Data are treated as intensities; noise is sampled as `Poisson(proj * s) / s`. Larger `s` → lower relative noise. Set 0 to disable.
+- Deterministic schedules:
+  - `--pert dof:shape[:k=v,...]` to add a schedule; repeatable. DOFs: `angle,alpha,beta,phi,dx,dz`. Shapes: `linear`, `sin-window`, `step`, `box`.
+  - `--spec <json>` to load schedules from a file. See `docs/misalign_modes.md`.
+  - `--with-random` to add random jitter on top of deterministic schedules (by default, schedules alone are used when present).
 
 Examples
 ```
@@ -70,6 +75,14 @@ pixi run misalign --data data/sim_aligned.nxs --out data/sim_misaligned.nxs \
 # Misalignment + Poisson noise
 pixi run misalign --data data/sim_aligned.nxs --out data/sim_misaligned_poisson.nxs \
   --rot-deg 1.0 --trans-px 10 --poisson 5000 --seed 0 --progress
+
+# Deterministic schedules (see docs/misalign_modes.md)
+# Linear angle drift 0→+5° across the scan
+pixi run misalign --data data/sim_aligned.nxs --out runs/mis_angle_lin.nxs \
+  --pert angle:linear:delta=5deg
+# Sudden dx shift of +5 px at 90° (held to end)
+pixi run misalign --data data/sim_aligned.nxs --out runs/mis_dx_step.nxs \
+  --pert dx:step:at=90deg,to=5px
 ```
 
 

--- a/docs/misalign_modes.md
+++ b/docs/misalign_modes.md
@@ -1,0 +1,129 @@
+# Misalignment Modes and Schedules (misalign CLI)
+
+The `misalign` CLI can now generate deterministic, reproducible misalignments in addition to the original random per‑view jitter. Deterministic schedules are composable and target individual degrees of freedom (DOFs):
+
+- DOFs: `angle`, `alpha`, `beta`, `phi`, `dx`, `dz`
+  - `angle`: adds an offset (in degrees) to the scan angles (`thetas_deg`) before building poses.
+  - `alpha`, `beta`, `phi`: small rotations (input in degrees; stored as radians).
+  - `dx`, `dz`: detector translations in pixels (u and v axes; scaled by `du` and `dv` to world units).
+
+You describe each schedule with `--pert` or an external JSON `--spec` file. Multiple schedules can be combined additively, in the order specified.
+
+## Quick Examples
+
+- Linear drift in angles 0 → +5° across the scan:
+  - `pixi run misalign --data data/sim.nxs --out runs/mis_angle_lin.nxs --pert angle:linear:delta=5deg`
+
+- Sinusoidal `dx` drift peaking mid‑scan at +5 px:
+  - `pixi run misalign --data data/sim.nxs --out runs/mis_dx_sin.nxs --pert dx:sin-window:amp=5px`
+
+- Sudden `dx` shift to +5 px at 90° (held to end):
+  - `pixi run misalign --data data/sim.nxs --out runs/mis_dx_step.nxs --pert dx:step:at=90deg,to=5px`
+
+Combine schedules by repeating `--pert`:
+
+```
+pixi run misalign --data data/sim.nxs --out runs/mis_combo.nxs \
+  --pert angle:linear:delta=5deg \
+  --pert dx:sin-window:amp=5px
+```
+
+## CLI Reference
+
+- `--pert <dof>:<shape>[:k=v[,k=v...]]`
+  - DOFs: `angle`, `alpha`, `beta`, `phi`, `dx`, `dz` (aliases: `x|u -> dx`, `y|v -> dz`).
+  - Shapes: `linear`, `sin-window` (`sin`/`sinwin`), `step`, `box`.
+  - Units on values via suffix: `deg`, `px` (default by DOF: angles/rotations are degrees; translations are pixels).
+  - Domain: by default, parameters refer to scan angle (`domain=angle`). Index-based domain is supported with `domain=index`.
+
+- `--spec <path.json>`: JSON file describing schedules (see schema below).
+
+- `--with-random`: add the original random jitter on top of deterministic schedules. If omitted, schedules are used alone (no randomness).
+
+Other options remain unchanged (`--rot-deg`, `--trans-px`, `--seed`, `--poisson`, ...). When `--with-random` is set, `--rot-deg` and `--trans-px` control the random ranges.
+
+## Shapes and Parameters
+
+All shapes operate on a window. If no window is given, they cover the full scan.
+
+- Window parameters (angle domain): `start_deg`, `end_deg`
+- Window parameters (index domain): `start_index`, `end_index`
+
+Angle domain uses the nearest views to the specified degrees. Index domain clamps to `[0, n_views-1]`.
+
+### linear
+
+Apply a linear ramp within the window.
+
+- Keys: `delta`, optional `start`, `end` (if `start`/`end` supplied, they override `delta`).
+  - Examples:
+    - `angle:linear:delta=5deg` → 0° at first view, +5° at last.
+    - `dx:linear:start=0px,end=3px,start_deg=0,end_deg=90` → 0→3 px between 0–90°, clamped outside.
+
+### sin-window (sinwin, sin)
+
+Single-lobe sine within the window: `amp * sin(pi * t)` with `t ∈ [0, 1]` across the window.
+
+- Keys: `amp`
+  - Example: `dx:sin-window:amp=5px` → 0 px at 0°, +5 px at 90°, back to 0 px at 180°.
+
+### step
+
+Step at a specific angle or index; holds until the end or for a width.
+
+- Keys:
+  - Angle domain: `at` (alias `at_deg`), optional `width_deg` or `until_deg`
+  - Index domain: `at_index`, optional `width_index` or `until_index`
+  - Value: either `to` for an absolute target, or `delta` for a relative shift.
+  - Examples:
+    - `dx:step:at=90deg,to=5px` → `dx=+5 px` from ~90° to the end.
+    - `dz:step:domain=index,at_index=10,delta=-3px,width_index=4` → −3 px for 4 views.
+
+### box
+
+Box pulse: step up by `delta`, then down after a width (or at `until`).
+
+- Keys: same as `step` plus `width_deg`/`width_index`. Example:
+  - `dz:box:at=60deg,width_deg=20,delta=-4px` → −4 px between ~60° and ~80°.
+
+## JSON Spec File
+
+Two accepted schemas:
+
+1) Per-DOF lists
+
+```json
+{
+  "angle": [{"kind": "linear", "delta": "5deg"}],
+  "dx": [{"kind": "sin-window", "amp": "5px"}],
+  "dz": [{"kind": "step", "at": "90deg", "to": "5px"}]
+}
+```
+
+2) Unified list
+
+```json
+{
+  "schedules": [
+    {"dof": "angle", "kind": "linear", "delta": "5deg"},
+    {"dof": "dx", "kind": "sin-window", "amp": "5px"}
+  ]
+}
+```
+
+## Metadata and Outputs
+
+The output file persists:
+
+- Modified `thetas_deg` (angles after applying `angle` schedules).
+- `processing/tomojax/align/thetas`: per-view 5‑DOF `[alpha,beta,phi,dx,dz]` in radians (rot) and world units (trans).
+- If schedules were used:
+  - `processing/tomojax/align/angle_offset_deg`: per-view angle offset applied (degrees).
+  - `processing/tomojax/align` attribute `misalign_spec_json`: normalized spec for reproducibility.
+
+## Notes
+
+- Units: rotations (`alpha`,`beta`,`phi`) accept degrees (default) and are stored in radians; translations (`dx`,`dz`) accept pixels and are converted using `du`/`dv`.
+- Composition: schedules are added in the order given; `step:to=...` sets an absolute level by internally computing the needed delta at that point.
+- Randomness: if any `--pert`/`--spec` is present, random jitter is disabled by default. Use `--with-random` to enable it and combine.
+

--- a/docs/tutorial_end_to_end.md
+++ b/docs/tutorial_end_to_end.md
@@ -75,6 +75,19 @@ pixi run misalign \
   --rot-deg 1.0 --trans-px 10 \
   --seed 0 \
   --progress
+
+Deterministic misalignment schedules
+- For systematic drifts or steps, use `--pert` and/or `--spec` (see `docs/misalign_modes.md`). Examples:
+
+```
+# Linear angle drift 0→+5° across the scan
+pixi run misalign --data data/sim_aligned.nxs --out runs/mis_angle_lin.nxs \
+  --pert angle:linear:delta=5deg
+
+# Sinusoidal dx drift peaking at +5 px mid‑scan
+pixi run misalign --data data/sim_aligned.nxs --out runs/mis_dx_sin.nxs \
+  --pert dx:sin-window:amp=5px
+```
 ```
 
 

--- a/docs/tutorial_laminography.md
+++ b/docs/tutorial_laminography.md
@@ -44,6 +44,17 @@ pixi run misalign \
   --progress
 ```
 
+Deterministic misalignment schedules
+- For systematic drifts/steps, use `--pert`/`--spec` (see `docs/misalign_modes.md`). Examples:
+```bash
+# Angle linear drift 0→+5° across 360° scan
+pixi run misalign --data runs/lamino_demo.nxs --out runs/lamino_mis_angle_lin.nxs \
+  --pert angle:linear:delta=5deg
+# dz box pulse −4 px between ~60° and ~80°
+pixi run misalign --data runs/lamino_demo.nxs --out runs/lamino_mis_dz_box.nxs \
+  --pert dz:box:at=60deg,width_deg=20,delta=-4px
+```
+
 ## Create misaligend noisy dataset
 ```bash
 pixi run misalign \

--- a/docs/tutorial_single_sample.md
+++ b/docs/tutorial_single_sample.md
@@ -80,6 +80,19 @@ pixi run misalign \
   --rot-deg 3.0 --trans-px 5 \
   --seed 0 \
   --progress
+
+Deterministic misalignment schedules
+- For systematic drifts/steps, use `--pert` and/or `--spec` (see `docs/misalign_modes.md`). Examples:
+
+```
+# Angle linear drift 0→+5° across the scan
+pixi run misalign --data data/sim_single.nxs --out runs/single_mis_angle_lin.nxs \
+  --pert angle:linear:delta=5deg
+
+# dx sinusoidal drift peaking +5 px at mid‑scan
+pixi run misalign --data data/sim_single.nxs --out runs/single_mis_dx_sin.nxs \
+  --pert dx:sin-window:amp=5px
+```
 ```
 
 

--- a/docs/tutorial_single_sample.md
+++ b/docs/tutorial_single_sample.md
@@ -1,0 +1,165 @@
+# TomoJAX Next — Single‑Sample (Centered Cube/Sphere) Tutorial
+
+This guide mirrors the end‑to‑end tutorial but uses a single centered object — a
+cube or sphere — as the phantom. You will:
+
+1) simulate a centered single‑object phantom, 2) create a misaligned forward model,
+3) optionally add noise, 4) run naive FBP, 5) run iterative alignment + reconstruction.
+
+All commands assume you are inside the pixi environment:
+
+- Enter the environment: `pixi shell`
+- One‑time install of the package: `pixi run install-root`
+- Show progress bars: `export TOMOJAX_PROGRESS=1`
+
+
+## 0) Quick Warmup (optional)
+
+```
+pixi run test-gpu
+pixi run simulate \
+  --out data/sim_single_small.nxs \
+  --nx 32 --ny 32 --nz 32 \
+  --nu 32 --nv 32 --n-views 32 \
+  --phantom sphere --single-size 0.6 --single-value 1.0 \
+  --seed 1 \
+  --progress
+pixi run misalign --data data/sim_single_small.nxs --out data/sim_single_misaligned_small.nxs --rot-deg 1 --trans-px 4 --seed 0 --progress
+```
+
+Notes
+- First projector/align call compiles with XLA; subsequent runs are faster.
+
+
+## 1) Simulate a 256³ Single‑Object Phantom
+
+Choose `sphere` (default below) or `cube`. The `--single-size` parameter is a
+relative fraction of the minimum dimension: for a sphere it is the diameter; for
+a cube it is the side length. The object is centered in the volume. For `cube`, a
+random 3D rotation is applied by default for a more interesting sample (disable
+with `--no-single-rotate`).
+
+```
+pixi run simulate \
+  --out data/sim_single.nxs \
+  --nx 256 --ny 256 --nz 256 \
+  --nu 256 --nv 256 --n-views 200 \
+  --phantom sphere \
+  --single-size 0.3 --single-value 1.0 \
+  --seed 42 \
+  --progress
+```
+
+Alternative (cube): (random 3D rotation by default)
+
+```
+pixi run simulate \
+  --out data/sim_single.nxs \
+  --nx 256 --ny 256 --nz 256 \
+  --nu 256 --nv 256 --n-views 200 \
+  --phantom cube \
+  --single-size 0.3 --single-value 0.3 \
+  --seed 69 \
+  --progress
+# To force an axis-aligned cube instead, add --no-single-rotate
+```
+
+Notes
+- Geometry defaults to parallel‑beam; detector matches the volume size.
+- Datasets are saved as NeXus (NXtomo) with geometry/grid metadata.
+
+
+## 2) Create a Misaligned Forward Model
+
+Apply per‑view perturbations to create a misaligned dataset:
+
+```
+pixi run misalign \
+  --data data/sim_single.nxs \
+  --out data/sim_single_misaligned.nxs \
+  --rot-deg 3.0 --trans-px 5 \
+  --seed 0 \
+  --progress
+```
+
+
+## 3) Add Poisson Noise (optional)
+
+```
+pixi run misalign \
+  --data data/sim_single.nxs \
+  --out data/sim_single_misaligned_poisson.nxs \
+  --rot-deg 3.0 --trans-px 5 \
+  --poisson 10 \
+  --seed 0 \
+  --progress
+```
+
+
+## 4) Naive FBP Reconstructions
+
+```
+# Misaligned
+pixi run recon \
+  --data data/sim_single_misaligned.nxs \
+  --algo fbp --filter ramp \
+  --gather-dtype bf16 --checkpoint-projector \
+  --out out/fbp_single_misaligned.nxs \
+  --progress
+
+# Noisy + misaligned
+pixi run recon \
+  --data data/sim_single_misaligned_poisson.nxs \
+  --algo fbp --filter ramp \
+  --gather-dtype bf16 --checkpoint-projector \
+  --out out/fbp_single_misaligned_noisy.nxs \
+  --progress
+```
+
+
+## 5) Iterative Alignment + Reconstruction (Levels [4, 2, 1])
+
+```
+# Misaligned (clean)
+pixi run align \
+  --data data/sim_single_misaligned.nxs \
+  --levels 4 2 1 \
+  --outer-iters 10 --recon-iters 15 --lambda-tv 0.003 \
+  --opt-method gn --gn-damping 1e-3 \
+  --gather-dtype bf16 --checkpoint-projector \
+  --log-summary \
+  --out out/align_single_misaligned.nxs \
+  --progress
+
+# Noisy + misaligned
+pixi run align \
+  --data data/sim_single_misaligned_poisson.nxs \
+  --levels 4 2 1 \
+  --outer-iters 5 --recon-iters 10 --lambda-tv 0.1 --tv-prox-iters 10 \
+  --opt-method gn --gn-damping 1e-3 \
+  --gather-dtype bf16 --checkpoint-projector \
+  --log-summary \
+  --out out/align_single_misaligned_noisy.nxs \
+  --progress
+```
+
+Tips
+- Keep projector checkpointing enabled and prefer `--gather-dtype bf16` when on GPU.
+- Increase `--lambda-tv` and `--tv-prox-iters` for heavy noise.
+
+
+## 6) Outputs
+
+Compare:
+- Naive FBP: `out/fbp_single_misaligned.nxs`, `out/fbp_single_misaligned_noisy.nxs`
+- Aligned: `out/align_single_misaligned.nxs`, `out/align_single_misaligned_noisy.nxs`
+
+Aligned outputs include per‑view alignment parameters.
+
+
+## Appendix — Key Flags
+
+- `--phantom {sphere,cube}` with `--single-size` (diameter/side as fraction of min dim) and `--single-value`.
+- `--gather-dtype {auto,fp32,bf16,fp16}`; `bf16` recommended on modern GPUs.
+- `--[no-]checkpoint-projector` to trade compute for memory.
+- `--opt-method {gn,gd}`; GN is typically faster to high quality.

--- a/src/tomojax/cli/align.py
+++ b/src/tomojax/cli/align.py
@@ -96,6 +96,9 @@ def main() -> None:
     p.add_argument("--w-trans", type=float, default=1e-3, help="Smoothness weight for translations")
     p.add_argument("--seed-translations", action="store_true", help="Phase-correlation init for dx,dz at coarsest level")
     p.add_argument("--log-summary", action="store_true", help="Print per-outer summaries (FISTA loss, alignment loss before/after)")
+    p.add_argument("--log-compact", dest="log_compact", action="store_true", default=True,
+                   help="Use compact one-line per-outer summary when --log-summary is set (default: on)")
+    p.add_argument("--no-log-compact", dest="log_compact", action="store_false")
     p.add_argument("--recon-L", type=float, default=None, help="Fixed Lipschitz constant for FISTA inside alignment (skip power-method)")
     p.add_argument(
         "--transfer-guard",
@@ -141,6 +144,7 @@ def main() -> None:
         w_trans=float(args.w_trans),
         seed_translations=bool(args.seed_translations),
         log_summary=bool(args.log_summary),
+        log_compact=bool(args.log_compact),
         recon_L=(float(args.recon_L) if args.recon_L is not None else None),
     )
     if args.levels is not None and len(args.levels) > 0:

--- a/src/tomojax/cli/align.py
+++ b/src/tomojax/cli/align.py
@@ -100,6 +100,13 @@ def main() -> None:
                    help="Use compact one-line per-outer summary when --log-summary is set (default: on)")
     p.add_argument("--no-log-compact", dest="log_compact", action="store_false")
     p.add_argument("--recon-L", type=float, default=None, help="Fixed Lipschitz constant for FISTA inside alignment (skip power-method)")
+    # Early stopping controls (alignment phase)
+    es = p.add_mutually_exclusive_group()
+    es.add_argument("--early-stop", dest="early_stop", action="store_true", help="Enable early stopping across outers (default)")
+    es.add_argument("--no-early-stop", dest="early_stop", action="store_false", help="Disable early stopping across outers")
+    p.set_defaults(early_stop=True)
+    p.add_argument("--early-stop-rel", type=float, default=None, help="Relative improvement threshold for early stop (default 1e-3)")
+    p.add_argument("--early-stop-patience", type=int, default=None, help="Consecutive outers below threshold before stopping (default 2)")
     p.add_argument(
         "--transfer-guard",
         choices=["off", "log", "disallow"],
@@ -146,6 +153,9 @@ def main() -> None:
         log_summary=bool(args.log_summary),
         log_compact=bool(args.log_compact),
         recon_L=(float(args.recon_L) if args.recon_L is not None else None),
+        early_stop=bool(args.early_stop),
+        early_stop_rel_impr=(float(args.early_stop_rel) if args.early_stop_rel is not None else 1e-3),
+        early_stop_patience=(int(args.early_stop_patience) if args.early_stop_patience is not None else 2),
     )
     if args.levels is not None and len(args.levels) > 0:
         from ..align.pipeline import align_multires

--- a/src/tomojax/cli/misalign.py
+++ b/src/tomojax/cli/misalign.py
@@ -15,12 +15,309 @@ from ..core.projector import forward_project_view_T
 from ..utils.logging import setup_logging, log_jax_env
 
 
+def _transfer_guard_ctx(mode: str | None = None):
+    # Allow overriding via env var: off|log|disallow
+    if mode is None:
+        mode = os.environ.get("TOMOJAX_TRANSFER_GUARD", "log").lower()
+    if mode in ("off", "none", "disable", "disabled"):
+        return _nullcontext()
+    try:
+        tg = getattr(jax, "transfer_guard", None)
+        if tg is not None:
+            return tg(mode)
+        try:
+            from jax.experimental import transfer_guard as _tg  # type: ignore
+            return _tg(mode)
+        except Exception:
+            return _nullcontext()
+    except Exception:
+        return _nullcontext()
+
+
+def _parse_bool(s: str) -> bool:
+    s = s.strip().lower()
+    if s in ("1", "true", "yes", "y", "on"):
+        return True
+    if s in ("0", "false", "no", "n", "off"):
+        return False
+    raise ValueError(f"Invalid boolean value: {s}")
+
+
+def _parse_number_with_unit(val: str) -> tuple[float, str | None]:
+    """Parse a number with optional unit suffix.
+
+    Supports suffixes: deg, rad, px. Returns (value, unit_or_None).
+    """
+    s = val.strip().lower()
+    for suf in ("deg", "rad", "px"):
+        if s.endswith(suf):
+            num = float(s[: -len(suf)])
+            return num, suf
+    return float(s), None
+
+
+def _parse_pert(spec: str) -> tuple[str, str, dict[str, str]]:
+    """Parse a --pert specification: dof:shape[:k=v[,k=v...]]"""
+    parts = spec.split(":", 2)
+    if len(parts) < 2:
+        raise ValueError(f"Invalid --pert spec (need dof:shape): {spec}")
+    dof = parts[0].strip().lower()
+    shape = parts[1].strip().lower()
+    params: dict[str, str] = {}
+    if len(parts) == 3 and parts[2].strip():
+        kvs = parts[2].split(",")
+        for kv in kvs:
+            if not kv:
+                continue
+            if "=" not in kv:
+                raise ValueError(f"Invalid param in --pert: '{kv}' (expected k=v)")
+            k, v = kv.split("=", 1)
+            params[k.strip().lower()] = v.strip()
+    # normalize aliases
+    if dof in ("x", "u"):
+        dof = "dx"
+    if dof in ("y", "v"):
+        dof = "dz"
+    return dof, shape, params
+
+
+def _domain_from_params(params: dict[str, str]) -> str:
+    d = params.get("domain", "angle").lower()
+    if d not in ("angle", "index"):
+        raise ValueError(f"Invalid domain: {d}")
+    return d
+
+
+def _window_indices_for_domain(
+    thetas_deg: jnp.ndarray,
+    n_views: int,
+    params: dict[str, str],
+) -> tuple[int, int]:
+    """Compute [start_idx, end_idx] inclusive for an optional window.
+
+    - angle domain: use start_deg/end_deg if provided, else full span
+    - index domain: use start_index/end_index if provided, else full span
+    """
+    d = _domain_from_params(params)
+    if d == "index":
+        si = int(params.get("start_index", 0))
+        ei = int(params.get("end_index", n_views - 1))
+        si = max(0, min(n_views - 1, si))
+        ei = max(si, min(n_views - 1, ei))
+        return si, ei
+    # angle domain
+    if "start_deg" in params or "end_deg" in params:
+        th = jnp.asarray(thetas_deg)
+        th0 = float(params.get("start_deg", float(th.min())))
+        th1 = float(params.get("end_deg", float(th.max())))
+        # pick closest indices bounding the window
+        si = int(jnp.argmin(jnp.abs(th - th0)))
+        ei = int(jnp.argmin(jnp.abs(th - th1)))
+        if ei < si:
+            si, ei = ei, si
+        return si, ei
+    return 0, n_views - 1
+
+
+def _apply_linear(schedule: np.ndarray, thetas_deg: jnp.ndarray, params: dict[str, str]) -> None:
+    """Apply a linear ramp inside a window to the given schedule array (in-place)."""
+    n = schedule.shape[0]
+    si, ei = _window_indices_for_domain(thetas_deg, n, params)
+    if ei <= si:
+        return
+    # Determine start and end offsets
+    start_off = 0.0
+    end_off = 0.0
+    if "delta" in params:
+        v, _u = _parse_number_with_unit(params["delta"])
+        end_off = float(v)
+    if "start" in params:
+        v, _u = _parse_number_with_unit(params["start"])
+        start_off = float(v)
+    if "end" in params:
+        v, _u = _parse_number_with_unit(params["end"])
+        end_off = float(v)
+    # Ramp
+    m = ei - si
+    ramp = np.linspace(0.0, 1.0, m + 1, dtype=np.float32)
+    vals = start_off + (end_off - start_off) * ramp
+    schedule[si : ei + 1] += vals
+
+
+def _apply_sin_window(schedule: np.ndarray, thetas_deg: jnp.ndarray, params: dict[str, str]) -> None:
+    """Apply a single-lobe sine window (0->amp->0) within a window."""
+    n = schedule.shape[0]
+    si, ei = _window_indices_for_domain(thetas_deg, n, params)
+    if ei <= si:
+        return
+    amp = float(_parse_number_with_unit(params.get("amp", "0"))[0])
+    m = ei - si
+    t = np.linspace(0.0, 1.0, m + 1, dtype=np.float32)
+    vals = amp * np.sin(np.pi * t)  # 0 at edges, amp at center
+    schedule[si : ei + 1] += vals
+
+
+def _apply_step(schedule: np.ndarray, thetas_deg: jnp.ndarray, params: dict[str, str]) -> None:
+    """Apply a step at angle or index.
+
+    Params:
+      - at_deg or at_index: where the step begins
+      - to: set absolute value to this within the step window (computed relative to current)
+      - delta: add this offset within the window
+      - width_deg / width_index: optional duration; if missing, holds to the end
+    """
+    n = schedule.shape[0]
+    d = _domain_from_params(params)
+    if d == "index":
+        at = int(params.get("at_index", 0))
+        at = max(0, min(n - 1, at))
+    else:
+        th = np.asarray(thetas_deg)
+        at_deg = float(_parse_number_with_unit(params.get("at", params.get("at_deg", "0")))[0])
+        at = int(np.argmin(np.abs(th - at_deg)))
+    if at >= n:
+        return
+    # Width / until
+    if d == "index":
+        if "width_index" in params:
+            end = min(n - 1, at + int(params["width_index"]))
+        elif "until_index" in params:
+            end = max(at, min(n - 1, int(params["until_index"])) )
+        else:
+            end = n - 1
+    else:
+        if "width_deg" in params:
+            width = float(_parse_number_with_unit(params["width_deg"])[0])
+            th = np.asarray(thetas_deg)
+            target = float(th[at]) + width
+            end = int(np.argmin(np.abs(th - target)))
+            end = max(at, min(n - 1, end))
+        elif "until_deg" in params:
+            target = float(_parse_number_with_unit(params["until_deg"])[0])
+            th = np.asarray(thetas_deg)
+            end = int(np.argmin(np.abs(th - target)))
+            end = max(at, min(n - 1, end))
+        else:
+            end = n - 1
+    # Delta or absolute target
+    if "to" in params:
+        tgt = float(_parse_number_with_unit(params["to"])[0])
+        # Compute relative delta to reach absolute target
+        delta = tgt - schedule[at]
+    else:
+        delta = float(_parse_number_with_unit(params.get("delta", "0"))[0])
+    schedule[at : end + 1] += delta
+
+
+def _apply_box(schedule: np.ndarray, thetas_deg: jnp.ndarray, params: dict[str, str]) -> None:
+    """Apply a box pulse: step up by delta at 'at', then down after a width."""
+    # Step up
+    _apply_step(schedule, thetas_deg, params)
+    # Step down
+    # Build params for the end step
+    end_params = dict(params)
+    if "width_index" in params or "until_index" in params:
+        if "width_index" in params:
+            end_params["at_index"] = str(int(params.get("at_index", params.get("at", 0))) + int(params["width_index"]))
+        # if until_index is present, we step down at that index
+        if "until_index" in params:
+            end_params["at_index"] = params["until_index"]
+    else:
+        # angle domain width
+        if "width_deg" in params:
+            # at + width
+            at_deg = float(_parse_number_with_unit(params.get("at", params.get("at_deg", "0")))[0])
+            end_params["at"] = str(at_deg + float(_parse_number_with_unit(params["width_deg"])[0]))
+        elif "until_deg" in params:
+            end_params["at"] = params["until_deg"]
+    # invert the step
+    if "to" in end_params:
+        # Returning to zero level (absolute)
+        end_params["to"] = "0"
+    elif "delta" in end_params:
+        v, _ = _parse_number_with_unit(end_params["delta"])
+        end_params["delta"] = str(-float(v))
+    _apply_step(schedule, thetas_deg, end_params)
+
+
+def _build_schedules(
+    thetas_deg: jnp.ndarray,
+    n_views: int,
+    perts: list[tuple[str, str, dict[str, str]]],
+) -> tuple[dict[str, np.ndarray], dict[str, list[dict[str, str]]]]:
+    """Construct per-DOF schedules and return also a normalized spec for metadata."""
+    schedules: dict[str, np.ndarray] = {k: np.zeros((n_views,), np.float32) for k in ("angle", "alpha", "beta", "phi", "dx", "dz")}
+    norm_spec: dict[str, list[dict[str, str]]] = {}
+    for dof, shape, params in perts:
+        if dof not in schedules:
+            raise ValueError(f"Unsupported DOF in --pert: {dof}")
+        norm_spec.setdefault(dof, []).append({"kind": shape, **params})
+        sched = schedules[dof]
+        if shape in ("linear", "lin"):
+            _apply_linear(sched, thetas_deg, params)
+        elif shape in ("sin-window", "sinwin", "sin"):
+            _apply_sin_window(sched, thetas_deg, params)
+        elif shape in ("step",):
+            _apply_step(sched, thetas_deg, params)
+        elif shape in ("box",):
+            _apply_box(sched, thetas_deg, params)
+        else:
+            raise ValueError(f"Unsupported shape: {shape}")
+    return schedules, norm_spec
+
+
+def _load_spec_file(path: str) -> list[tuple[str, str, dict[str, str]]]:
+    import json
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    out: list[tuple[str, str, dict[str, str]]] = []
+    # Two accepted layouts:
+    # 1) { "dx": [{"kind":"step", ...}], "angle": [{...}], ... }
+    # 2) { "schedules": [{"dof":"dx","kind":"step",...}, ...] }
+    if isinstance(data, dict) and any(k in data for k in ("angle", "alpha", "beta", "phi", "dx", "dz")):
+        for dof, lst in data.items():
+            if dof not in ("angle", "alpha", "beta", "phi", "dx", "dz"):
+                continue
+            if not isinstance(lst, list):
+                raise ValueError(f"Spec field for {dof} must be a list")
+            for item in lst:
+                if not isinstance(item, dict) or "kind" not in item:
+                    raise ValueError(f"Spec items for {dof} must be dicts with 'kind'")
+                    
+                kind = str(item["kind"]).lower()
+                params = {k: str(v) for k, v in item.items() if k != "kind"}
+                out.append((dof, kind, params))
+    elif isinstance(data, dict) and "schedules" in data and isinstance(data["schedules"], list):
+        for it in data["schedules"]:
+            if not isinstance(it, dict) or "dof" not in it or "kind" not in it:
+                raise ValueError("Each schedule must have 'dof' and 'kind'")
+            dof = str(it["dof"]).lower()
+            kind = str(it["kind"]).lower()
+            params = {k: str(v) for k, v in it.items() if k not in ("dof", "kind")}
+            out.append((dof, kind, params))
+    else:
+        raise ValueError("Unrecognized spec file schema")
+    # Normalize aliases in dof
+    normed = []
+    for dof, kind, params in out:
+        if dof in ("x", "u"):
+            dof = "dx"
+        if dof in ("y", "v"):
+            dof = "dz"
+        normed.append((dof, kind, params))
+    return normed
+
+
 def main() -> None:
     p = argparse.ArgumentParser(description="Create a misaligned (and optionally noisy) dataset from a ground-truth NXtomo file.")
     p.add_argument("--data", required=True, help="Input .nxs containing ground-truth volume and geometry")
     p.add_argument("--out", required=True, help="Output .nxs path")
-    p.add_argument("--rot-deg", type=float, default=1.0, help="Max abs rotation per-axis (alpha,beta,phi) in degrees")
-    p.add_argument("--trans-px", type=float, default=10.0, help="Max abs translation in detector pixels (dx,dz)")
+    p.add_argument("--rot-deg", type=float, default=1.0, help="Max abs rotation per-axis (alpha,beta,phi) in degrees (used for --with-random)")
+    p.add_argument("--trans-px", type=float, default=10.0, help="Max abs translation in detector pixels (dx,dz) (used for --with-random)")
+    # New deterministic perturbation modes
+    p.add_argument("--pert", action="append", default=[], help="Additive schedule spec: dof:shape[:k=v[,k=v...]]; dof in {angle,alpha,beta,phi,dx,dz}")
+    p.add_argument("--spec", type=str, default=None, help="JSON file with schedules; see docs/misalign_modes.md")
+    p.add_argument("--with-random", action="store_true", help="Combine random misalignment on top of deterministic schedules")
     p.add_argument("--seed", type=int, default=0, help="RNG seed for misalignment")
     p.add_argument("--poisson", type=float, default=0.0, help="Photons per pixel for Poisson noise (0 disables)")
     p.add_argument("--progress", action="store_true", help="Show progress bars if tqdm is available")
@@ -65,18 +362,59 @@ def main() -> None:
 
     vol = jnp.asarray(meta["volume"], jnp.float32)
     n_views = int(len(thetas))
-    T_nom = jnp.stack([jnp.asarray(geom.pose_for_view(i), jnp.float32) for i in range(n_views)], axis=0)
 
-    # Random per-view parameters
-    rng = np.random.default_rng(args.seed)
-    rot_scale = np.float32(np.deg2rad(float(args.rot_deg)))
-    params5 = np.zeros((n_views, 5), np.float32)
-    params5[:, 0] = rng.uniform(-rot_scale, rot_scale, n_views)  # alpha
-    params5[:, 1] = rng.uniform(-rot_scale, rot_scale, n_views)  # beta
-    params5[:, 2] = rng.uniform(-rot_scale, rot_scale, n_views)  # phi
-    params5[:, 3] = rng.uniform(-float(args.trans_px), float(args.trans_px), n_views).astype(np.float32) * float(det.du)
-    params5[:, 4] = rng.uniform(-float(args.trans_px), float(args.trans_px), n_views).astype(np.float32) * float(det.dv)
-    params5 = jnp.asarray(params5, jnp.float32)
+    # Build deterministic schedules if requested
+    pert_specs: list[tuple[str, str, dict[str, str]]] = []
+    if args.spec:
+        pert_specs.extend(_load_spec_file(args.spec))
+    for s in args.pert:
+        pert_specs.append(_parse_pert(s))
+
+    # Set base angles and params
+    thetas_used = np.asarray(thetas, dtype=np.float32)
+    angle_offset = np.zeros((n_views,), dtype=np.float32)
+    params5_np = np.zeros((n_views, 5), dtype=np.float32)
+
+    misalign_spec_dict = None
+    if pert_specs:
+        schedules, norm_spec = _build_schedules(jnp.asarray(thetas, jnp.float32), n_views, pert_specs)
+        misalign_spec_dict = norm_spec
+        # Apply angle offset
+        angle_offset = schedules.get("angle", angle_offset).astype(np.float32)
+        thetas_used = thetas_used + angle_offset
+        # Apply DOF schedules
+        # Rotations: alpha,beta,phi input assumed in degrees unless rad suffix was used;
+        # schedules are raw numeric; interpret as degrees for rotations, convert to radians here.
+        for i, k in enumerate(["alpha", "beta", "phi"]):
+            if k in schedules:
+                params5_np[:, i] += np.deg2rad(schedules[k].astype(np.float32))
+        # Translations in pixels -> world units by du/dv
+        if "dx" in schedules:
+            params5_np[:, 3] += schedules["dx"].astype(np.float32) * float(det.du)
+        if "dz" in schedules:
+            params5_np[:, 4] += schedules["dz"].astype(np.float32) * float(det.dv)
+
+    # Random per-view parameters (optional)
+    if (not pert_specs) or args.with_random:
+        rng = np.random.default_rng(args.seed)
+        rot_scale = np.float32(np.deg2rad(float(args.rot_deg)))
+        params5_np[:, 0] += rng.uniform(-rot_scale, rot_scale, n_views).astype(np.float32)  # alpha
+        params5_np[:, 1] += rng.uniform(-rot_scale, rot_scale, n_views).astype(np.float32)  # beta
+        params5_np[:, 2] += rng.uniform(-rot_scale, rot_scale, n_views).astype(np.float32)  # phi
+        params5_np[:, 3] += rng.uniform(-float(args.trans_px), float(args.trans_px), n_views).astype(np.float32) * float(det.du)
+        params5_np[:, 4] += rng.uniform(-float(args.trans_px), float(args.trans_px), n_views).astype(np.float32) * float(det.dv)
+
+    # Rebuild T_nom with possibly modified thetas
+    if geom_type == "parallel":
+        geom = ParallelGeometry(grid=grid, detector=det, thetas_deg=thetas_used)
+    else:
+        tilt_deg = float(meta.get("tilt_deg", 30.0))
+        tilt_about = str(meta.get("tilt_about", "x"))
+        geom = LaminographyGeometry(grid=grid, detector=det, thetas_deg=thetas_used, tilt_deg=tilt_deg, tilt_about=tilt_about)
+
+    # Recompute nominal poses with final geometry (possibly modified angles)
+    T_nom = jnp.stack([jnp.asarray(geom.pose_for_view(i), jnp.float32) for i in range(n_views)], axis=0)
+    params5 = jnp.asarray(params5_np, jnp.float32)
 
     with _transfer_guard_ctx(args.transfer_guard):
         T_aug = T_nom @ jax.vmap(se3_from_5d)(params5)
@@ -95,13 +433,15 @@ def main() -> None:
     save_nxtomo(
         args.out,
         projections=np.asarray(proj),
-        thetas_deg=np.asarray(thetas),
+        thetas_deg=np.asarray(thetas_used),
         grid=grid.to_dict(),
         detector=det.to_dict(),
         geometry_type=geom_type,
         geometry_meta=meta.get("geometry_meta"),
         volume=np.asarray(vol),
         align_params=np.asarray(params5),
+        angle_offset_deg=np.asarray(angle_offset) if pert_specs else None,
+        misalign_spec=misalign_spec_dict,
         frame=str(meta.get("frame", "sample")),
     )
     logging.info("Wrote dataset: %s", args.out)
@@ -109,20 +449,3 @@ def main() -> None:
 
 if __name__ == "__main__":  # pragma: no cover
     main()
-def _transfer_guard_ctx(mode: str | None = None):
-    # Allow overriding via env var: off|log|disallow
-    if mode is None:
-        mode = os.environ.get("TOMOJAX_TRANSFER_GUARD", "log").lower()
-    if mode in ("off", "none", "disable", "disabled"):
-        return _nullcontext()
-    try:
-        tg = getattr(jax, "transfer_guard", None)
-        if tg is not None:
-            return tg(mode)
-        try:
-            from jax.experimental import transfer_guard as _tg  # type: ignore
-            return _tg(mode)
-        except Exception:
-            return _nullcontext()
-    except Exception:
-        return _nullcontext()

--- a/src/tomojax/cli/simulate.py
+++ b/src/tomojax/cli/simulate.py
@@ -29,9 +29,17 @@ def main() -> None:
     p.add_argument("--tilt-about", choices=["x", "z"], default="x")
     p.add_argument(
         "--phantom",
-        choices=["shepp", "cube", "blobs", "random_shapes", "lamino_disk"],
+        choices=["shepp", "cube", "sphere", "blobs", "random_shapes", "lamino_disk"],
         default="shepp",
+        help="Phantom type. Use 'cube' or 'sphere' for a single centered object.",
     )
+    # rotate the single cube randomly by default; sphere is unaffected
+    p.add_argument("--single-rotate", dest="single_rotate", action="store_true", default=True,
+                   help="Rotate the single cube randomly in 3D (default: on)")
+    p.add_argument("--no-single-rotate", dest="single_rotate", action="store_false")
+    # single-object phantom args (used for phantom=cube|sphere)
+    p.add_argument("--single-size", type=float, default=0.5, help="Relative size of cube side or sphere diameter (0-1). Default 0.5")
+    p.add_argument("--single-value", type=float, default=1.0, help="Intensity value for the single object")
     # random_shapes args
     p.add_argument("--n-cubes", type=int, default=8)
     p.add_argument("--n-spheres", type=int, default=7)
@@ -69,6 +77,7 @@ def main() -> None:
         geometry=args.geometry, tilt_deg=args.tilt_deg, tilt_about=args.tilt_about,
         rotation_deg=(float(args.rotation_deg) if args.rotation_deg is not None else None),
         phantom=args.phantom, noise=args.noise, noise_level=args.noise_level, seed=args.seed,
+        single_size=args.single_size, single_value=args.single_value, single_rotate=bool(args.single_rotate),
         n_cubes=args.n_cubes, n_spheres=args.n_spheres,
         min_size=args.min_size, max_size=args.max_size,
         min_value=args.min_value, max_value=args.max_value,

--- a/src/tomojax/utils/logging.py
+++ b/src/tomojax/utils/logging.py
@@ -9,6 +9,16 @@ from typing import Iterable, Iterator, Optional
 def setup_logging(level: str = "INFO") -> None:
     lvl = getattr(logging, level.upper(), logging.INFO)
     logging.basicConfig(level=lvl, format="%(asctime)s | %(levelname)s | %(message)s")
+    # Quiet noisy backend probe logs from JAX unless explicitly enabled
+    if os.environ.get("TOMOJAX_BACKEND_LOG", "0").lower() not in ("1", "true", "yes", "on"):
+        for name in (
+            "jax._src.xla_bridge",
+            "jax._src.xla_client",
+        ):
+            try:
+                logging.getLogger(name).setLevel(logging.WARNING)
+            except Exception:
+                pass
 
 
 def log_jax_env() -> None:

--- a/tests/test_misalign_schedules.py
+++ b/tests/test_misalign_schedules.py
@@ -1,0 +1,96 @@
+import os
+import sys
+import json
+import numpy as np
+import jax.numpy as jnp
+import pytest
+
+from tomojax.core.geometry import Grid, Detector
+from tomojax.data.io_hdf5 import save_nxtomo, load_nxtomo
+
+
+if sys.version_info < (3, 8):
+    pytest.skip("Requires Python 3.8+ for package code", allow_module_level=True)
+
+
+def _make_gt(path, nx=16, ny=16, nz=16, n_views=8):
+    grid = Grid(nx=nx, ny=ny, nz=nz, vx=1.0, vy=1.0, vz=1.0)
+    det = Detector(nu=nx, nv=nz, du=1.0, dv=1.0, det_center=(0.0, 0.0))
+    thetas = np.linspace(0.0, 180.0, n_views, endpoint=False)
+    # Simple phantom: centered cube
+    vol = jnp.zeros((nx, ny, nz), dtype=jnp.float32)
+    vol = vol.at[nx//4:3*nx//4, ny//4:3*ny//4, nz//4:3*nz//4].set(1.0)
+    save_nxtomo(
+        path,
+        projections=np.zeros((n_views, nz, nx), dtype=np.float32),  # placeholder; misalign will forward project
+        thetas_deg=thetas,
+        grid=grid,
+        detector=det,
+        volume=np.asarray(vol),
+        geometry_type="parallel",
+    )
+    return grid, det, thetas
+
+
+def _run_cli(tmp_path, in_path, out_path, args):
+    # Invoke CLI main via module import to avoid subprocess overhead
+    from tomojax.cli import misalign as cli
+    argv = ["misalign", "--data", in_path, "--out", out_path] + args
+    sys_argv_backup = sys.argv[:]
+    try:
+        sys.argv = argv
+        cli.main()
+    finally:
+        sys.argv = sys_argv_backup
+
+
+def test_angle_linear_updates_thetas(tmp_path):
+    in_path = os.path.join(tmp_path, "gt.nxs")
+    out_path = os.path.join(tmp_path, "out_angle_lin.nxs")
+    _grid, _det, thetas = _make_gt(in_path, n_views=8)
+
+    _run_cli(tmp_path, in_path, out_path, ["--pert", "angle:linear:delta=5deg"]) 
+    data = load_nxtomo(out_path)
+    th_out = np.asarray(data["thetas_deg"]).astype(np.float32)
+    off = th_out - thetas
+    # Expect roughly a 0->5 deg ramp across views
+    assert off.min() == pytest.approx(0.0, abs=1e-3)
+    assert off.max() == pytest.approx(5.0, abs=5e-2)
+    # No random unless requested
+    ap = np.asarray(data.get("align_params"))
+    assert ap is not None
+    assert np.allclose(ap, 0.0, atol=1e-1)
+
+
+def test_dx_sin_window_peak(tmp_path):
+    in_path = os.path.join(tmp_path, "gt.nxs")
+    out_path = os.path.join(tmp_path, "out_dx_sin.nxs")
+    _grid, det, thetas = _make_gt(in_path, n_views=8)
+
+    _run_cli(tmp_path, in_path, out_path, ["--pert", "dx:sin-window:amp=5px"]) 
+    data = load_nxtomo(out_path)
+    ap = np.asarray(data["align_params"]).astype(np.float32)
+    # dx is column 3, in world units (du=1)
+    dx = ap[:, 3]
+    assert dx.shape[0] == thetas.shape[0]
+    # Peak approximately 5 (sin-window) in pixels * du
+    assert dx.max() == pytest.approx(5.0 * float(det.du), abs=0.5)
+    # Rotational params should be near zero without randomness
+    assert np.allclose(ap[:, :3], 0.0, atol=1e-1)
+
+
+def test_dx_step_absolute_hold(tmp_path):
+    in_path = os.path.join(tmp_path, "gt.nxs")
+    out_path = os.path.join(tmp_path, "out_dx_step.nxs")
+    _grid, det, thetas = _make_gt(in_path, n_views=8)
+
+    _run_cli(tmp_path, in_path, out_path, ["--pert", "dx:step:at=90deg,to=5px"]) 
+    data = load_nxtomo(out_path)
+    ap = np.asarray(data["align_params"]).astype(np.float32)
+    dx = ap[:, 3]
+    # Find index closest to 90 deg
+    at = int(np.argmin(np.abs(thetas - 90.0)))
+    # Before step ~0, after step ~5px*du
+    assert np.allclose(dx[:at], 0.0, atol=0.25)
+    assert np.allclose(dx[at:], 5.0 * float(det.du), atol=0.25)
+


### PR DESCRIPTION
Expose alignment early stopping controls in the align CLI.

Why
- Early stopping across outer iterations can be too aggressive for some datasets; previously it wasn’t adjustable from the CLI.

Changes
- New flags:
  - --no-early-stop: disable early stopping across outers.
  - --early-stop: explicitly enable (default behaviour).
  - --early-stop-rel <float>: relative improvement threshold (default 1e-3).
  - --early-stop-patience <int>: consecutive outers below threshold before stopping (default 2).
- Wired through to AlignConfig. Defaults unchanged.
- Updated docs/cli_reference.md to document the flags.

Usage
- Disable early stopping entirely:
  pixi run align --data data/sim_misaligned.nxs --no-early-stop --out runs/align_no_es.nxs
- Make ES less aggressive (smaller threshold, higher patience):
  pixi run align --data data/sim_misaligned.nxs --early-stop-rel 1e-4 --early-stop-patience 5 --out runs/align_tuned_es.nxs
