### PR TITLE
fix: avoid tensorcore matmul in projector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Recon CLI now crops to detector FOV by default (`--roi auto`); pass `--roi off` to keep legacy behavior.
 - Normalize NX volume IO: write volumes on disk in `zyx` order with `@volume_axes_order` metadata, transpose on load, and warn (silence via `TOMOJAX_AXES_SILENCE`).
 - Add CLI `--volume-axes` override for `recon`/`align` and update NX data wrangler to tag volumes.
+- Fix CUDA “invalid image” faults on Turing GPUs by replacing the projector’s small GEMM with element-wise transforms, ensuring SPDHG/FWD projections compile cleanly on RTX 6000/8000 while keeping mixed-precision gather heuristics.
 
 ## 0.2.0 — v2 at repo root
 - Promote the v2 implementation to the primary package at `tomojax`.

--- a/src/tomojax/core/projector.py
+++ b/src/tomojax/core/projector.py
@@ -190,7 +190,13 @@ def forward_project_view_T(
     tinv = -(Rinv @ t)
     ey_obj = Rinv[:, 1]  # world +y axis mapped into object frame (beam dir in object coords)
 
-    base = Rinv @ jnp.stack([Xr, jnp.zeros_like(Xr), Zr], axis=0) + tinv[:, None]
+    xr = Xr[jnp.newaxis, :]
+    zr = Zr[jnp.newaxis, :]
+    base = (
+        Rinv[:, 0:1] * xr
+        + Rinv[:, 2:3] * zr
+        + tinv[:, None]
+    )
     y0 = vol_origin[1]
     q0 = base + y0 * ey_obj[:, None]
     dq = (step_size * ey_obj)[:, None]

--- a/src/tomojax/recon/spdhg_tv.py
+++ b/src/tomojax/recon/spdhg_tv.py
@@ -90,6 +90,9 @@ def _estimate_norm_A2(
     projector_unroll: int,
     checkpoint_projector: bool,
     gather_dtype: str,
+    key: jax.Array | None = None,
+    power_iters: int = 20,
+    safety: float = 1.05,
 ) -> float:
     """Reuse your power method to estimate ||A||^2 (i.e., Lipschitz of ∇(1/2||Ax||^2))."""
     # Minimal reimplementation: apply A^T A via VJP in streamed fashion over all views
@@ -138,14 +141,15 @@ def _estimate_norm_A2(
         g_final, _ = jax.lax.scan(body, g0, jnp.arange(m))
         return g_final
 
-    v = jnp.zeros((grid.nx, grid.ny, grid.nz), dtype=jnp.float32)
-    v = v.at[grid.nx//2, grid.ny//2, grid.nz//2].set(1.0)
+    if key is None:
+        key = jax.random.PRNGKey(0)
+    v = jax.random.normal(key, (grid.nx, grid.ny, grid.nz), dtype=jnp.float32)
     v = v / (jnp.linalg.norm(v) + 1e-12)
-    for _ in range(5):
+    for _ in range(max(1, power_iters)):
         w = AtranA(v)
         v = w / (jnp.linalg.norm(w) + 1e-12)
     Aw = AtranA(v)
-    L = float(jnp.vdot(v, Aw).real)  # ~||A||^2
+    L = float(jnp.vdot(v, Aw).real) * float(safety ** 2)  # ~||A||^2 with margin
     return max(L, 1e-6)
 
 
@@ -219,21 +223,24 @@ def spdhg_tv(
             projector_unroll=config.projector_unroll,
             checkpoint_projector=config.checkpoint_projector,
             gather_dtype=config.gather_dtype,
+            key=jax.random.PRNGKey(config.seed),
+            power_iters=20,
+            safety=1.05,
         )
         L_A = float(np.sqrt(L_A2))
         rho = 0.99
         tau = rho / (L_A + L_grad)
-        n_views_safe = max(n_views, 1)
-        p_ref = float(b) / float(n_views_safe)
-        sigma_data = rho * p_ref / max(L_A, 1e-6)
+        sigma_data_base = rho / max(L_A, 1e-6)
         sigma_tv = rho / L_grad
     else:
         tau = float(config.tau)
-        sigma_data = float(config.sigma_data)
+        sigma_data_base = float(config.sigma_data)
         sigma_tv = float(config.sigma_tv)
 
     # stochastic block schedule = random permutation of contiguous blocks per epoch
     m = (n_views + b - 1) // b
+    p_prob = 1.0 / float(max(m, 1))
+    sigma_data_eff = sigma_data_base * p_prob
     rng = np.random.default_rng(config.seed)
     epochs = (config.iters + m - 1) // m
     block_ids = []
@@ -277,9 +284,8 @@ def spdhg_tv(
         row_mask = (idx >= (jnp.int32(b) - valid))[:, None, None]
         row_mask = row_mask.astype(jnp.float32)
 
-        # DATA DUAL UPDATE (scaled by 1/p, p = valid/n_views)
-        p_block = jnp.maximum(valid.astype(jnp.float32) / float(n_views), 1e-8)
-        sigma_eff = sigma_data / p_block
+        # DATA DUAL UPDATE (constant step scaled by selection probability)
+        sigma_eff = jnp.asarray(sigma_data_eff, dtype=x_bar.dtype)
 
         pred = project_chunk(T_chunk, x_bar)
         u = y_dual_old + sigma_eff * pred
@@ -315,7 +321,8 @@ def spdhg_tv(
         x_new = _proj_pos_support(x_minus, config.positivity, support)
 
         # EXTRAGRAD
-        x_bar_new = x_new + jnp.asarray(config.theta, x_new.dtype) * (x_new - x)
+        x_bar_candidate = x_new + jnp.asarray(config.theta, x_new.dtype) * (x_new - x)
+        x_bar_new = _proj_pos_support(x_bar_candidate, config.positivity, support)
 
         # write back data dual window
         y_data_new = jax.lax.dynamic_update_slice(y_data, y_dual_new, (start_shifted, 0, 0))
@@ -351,9 +358,14 @@ def spdhg_tv(
 
     info = {
         "loss": [float(v) for v in list(losses_f)],
-        "tau": float(tau), "sigma_data": float(sigma_data), "sigma_tv": float(sigma_tv),
+        "tau": float(tau),
+        "sigma_data": float(sigma_data_eff),
+        "sigma_data_base": float(sigma_data_base),
+        "sigma_tv": float(sigma_tv),
         "lambda_tv": float(config.lambda_tv),
         "views_per_batch": int(b), "num_blocks": int(m),
-        "A_norm": (float(L_A) if L_A is not None else None), "grad_norm": float(L_grad),
+        "A_norm": (float(L_A) if L_A is not None else None),
+        "grad_norm": float(L_grad),
+        "selection_prob": float(p_prob),
     }
     return x_f, info

--- a/src/tomojax/utils/memory.py
+++ b/src/tomojax/utils/memory.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from typing import Optional
 import os
-
 import math
+from functools import lru_cache
+import subprocess
 
 
 def _bytes_per(dtype: str) -> int:
@@ -26,7 +27,7 @@ def device_free_memory_bytes() -> Optional[int]:
         import jax  # type: ignore
 
         if hasattr(jax, "device_get_memory_info"):
-            devs = jax.devices()
+            devs = jax.devices("gpu")
             if devs:
                 free, total = jax.device_get_memory_info(devs[0])  # type: ignore[attr-defined]
                 # On CPU backends, this may reflect host RAM; still usable as a bound
@@ -129,14 +130,77 @@ def default_gather_dtype() -> str:
     Returns "bf16" on GPU/TPU (mixed-precision gather with fp32 accumulation)
     and "fp32" on CPU or if backend detection fails.
     """
+    backend = _current_backend()
+    if isinstance(backend, str) and backend.lower() in ("gpu", "tpu"):
+        if backend.lower() == "tpu":
+            return "bf16"
+        cc = _gpu_compute_capability()
+        if cc and cc < (8, 0):
+            if _device_supports_dtype("float16"):
+                return "fp16"
+            return "fp32"
+        # GPU: prefer bf16 if the device JIT supports it, else fp16/fp32.
+        if _device_supports_dtype("bfloat16"):
+            return "bf16"
+        if _device_supports_dtype("float16"):
+            return "fp16"
+    return "fp32"
+
+
+@lru_cache(maxsize=None)
+def _device_supports_dtype(dtype_name: str) -> bool:
+    """Heuristic check whether the active accelerator can JIT kernels with `dtype`."""
+    try:
+        import jax  # type: ignore
+        import jax.numpy as jnp  # type: ignore
+    except Exception:
+        return False
+    try:
+        devs = jax.devices("gpu")
+    except Exception:
+        return False
+    if not devs:
+        return False
+    if devs[0].platform != "gpu":
+        return False
+    try:
+        # Simple kernel to trigger compilation in the requested dtype.
+        fn = jax.jit(lambda x: x + x)
+        dtype = getattr(jnp, dtype_name)
+        arr = jnp.ones((1,), dtype=dtype)
+        fn(arr).block_until_ready()
+        return True
+    except Exception:
+        return False
+
+
+@lru_cache(maxsize=None)
+def _gpu_compute_capability() -> Optional[tuple[int, int]]:
+    """Return (major, minor) compute capability for the first CUDA device, if available."""
+    try:
+        output = subprocess.check_output(
+            ["nvidia-smi", "--query-gpu=compute_cap", "--format=csv,noheader"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        first_line = output.strip().splitlines()[0]
+        parts = first_line.replace(" ", "").split(".")
+        if len(parts) >= 2:
+            major, minor = int(parts[0]), int(parts[1])
+            return major, minor
+    except Exception:
+        pass
+    return None
+
+
+def _current_backend() -> Optional[str]:
+    """Best-effort helper to query the active JAX backend name."""
     try:
         import jax  # type: ignore
 
         backend = getattr(jax, "default_backend", lambda: None)()
-        if isinstance(backend, str):
-            b = backend.lower()
-            if b in ("gpu", "tpu"):
-                return "bf16"
+        if backend:
+            return backend
+        return os.environ.get("JAX_PLATFORM_NAME")
     except Exception:
-        pass
-    return "fp32"
+        return None


### PR DESCRIPTION
Summary
  - replace the projector’s 3×N matmul with per-axis multiply-adds so XLA no longer emits SM80-only kernels on Turing
  GPUs
  - correct SPDHG auto stepping (seeded power iteration + probability scaling + constrained extragrad)
  - improve mixed-precision detection and add changelog entry for the CUDA “invalid image” fix

Testing
  - pixi run python -m pytest -q tests/test_spdhg.py
