### PR TITLE
refactor: simplify shared geometry and recon plumbing

### DIFF
--- a/src/tomojax/align/pipeline.py
+++ b/src/tomojax/align/pipeline.py
@@ -4,12 +4,13 @@ from dataclasses import dataclass, replace
 import logging
 import math
 import time
-from typing import Any, Callable, Dict, Tuple, Iterable, List, Optional, Literal
+from typing import Callable, Iterable, Literal, TypedDict
 
 import jax
 import jax.numpy as jnp
 
-from ..core.geometry import Geometry, Grid, Detector
+from ..core.geometry.base import Geometry, Grid, Detector
+from ..core.geometry.views import stack_view_poses
 from ..core.projector import forward_project_view_T, get_detector_grid_device
 from ..recon.fista_tv import fista_tv
 from ..utils.logging import progress_iter, format_duration
@@ -19,9 +20,39 @@ from ..utils.fov import cylindrical_mask_xy
 
 
 ObserverAction = Literal["continue", "advance_level", "stop_run"]
+type OuterStatValue = float | int | bool | str | None
+type OuterStat = dict[str, OuterStatValue]
+ObserverCallback = Callable[[jnp.ndarray, jnp.ndarray, OuterStat], ObserverAction | bool]
 
 
-def _normalize_observer_action(action: Any) -> ObserverAction:
+class AlignInfo(TypedDict):
+    loss: list[float]
+    L: float | None
+    outer_stats: list[OuterStat]
+    stopped_by_observer: bool
+    observer_action: ObserverAction
+    wall_time_total: float
+
+
+class AlignMultiresInfo(TypedDict):
+    loss: list[float]
+    factors: list[int]
+    stopped_by_observer: bool
+    observer_action: ObserverAction
+    total_outer_iters: int
+    wall_time_total: float
+
+
+class MultiresLevel(TypedDict):
+    factor: int
+    grid: Grid
+    detector: Detector
+    projections: jnp.ndarray
+
+
+def _normalize_observer_action(
+    action: ObserverAction | str | bool | None,
+) -> ObserverAction:
     if action is False or action is None:
         return "continue"
     if action is True:
@@ -167,7 +198,7 @@ class AlignConfig:
     projector_unroll: int = 1
     checkpoint_projector: bool = True
     gather_dtype: str = "fp32"
-    # Solver & regularization (GN and GD only; LBFGS removed)
+    # Solver and regularization
     opt_method: str = "gn"
     gn_damping: float = 1e-6
     w_rot: float = 0.0
@@ -185,17 +216,12 @@ class AlignConfig:
     early_stop: bool = True
     early_stop_rel_impr: float = 1e-3  # stop if (before-after)/before < this
     early_stop_patience: int = 2
-    # GN acceptance: only apply step if it reduces the alignment loss
-    # GN acceptance: only apply step if it improves, unless gn_accept_tol allows a tiny increase
+    # Accept GN steps only when they improve the loss, up to gn_accept_tol.
     gn_accept_only_improving: bool = True
     gn_accept_tol: float = 0.0  # allow tiny increases if >0 (as fraction of before)
     # Data term / similarity
     loss_kind: str = "l2_otsu"
-    loss_params: Optional[Dict[str, float]] = None
-    # (LBFGS settings removed)
-
-
- # (Removed: AugmentedGeometry legacy wrapper; new alignment path uses pose-aware projector directly)
+    loss_params: dict[str, float] | None = None
 
 
 def align(
@@ -207,8 +233,8 @@ def align(
     cfg: AlignConfig | None = None,
     init_x: jnp.ndarray | None = None,
     init_params5: jnp.ndarray | None = None,
-    observer: Callable[[jnp.ndarray, jnp.ndarray, Dict[str, Any]], ObserverAction | bool] | None = None,
-) -> Tuple[jnp.ndarray, jnp.ndarray, Dict]:
+    observer: ObserverCallback | None = None,
+) -> tuple[jnp.ndarray, jnp.ndarray, AlignInfo]:
     """Alternating reconstruction + per-view alignment (5-DOF) on small cases.
 
     Returns (x, params5, info) with loss history and optional metrics.
@@ -234,10 +260,7 @@ def align(
 
     # Precompute nominal poses once
     n_views = int(projections.shape[0])
-    T_nom_all = jnp.stack(
-        [jnp.asarray(geometry.pose_for_view(i), dtype=jnp.float32) for i in range(n_views)],
-        axis=0,
-    )
+    T_nom_all = stack_view_poses(geometry, n_views)
 
     # Precompute detector grid once (device arrays) to avoid repeated transfers/logging
     det_grid = get_detector_grid_device(detector)
@@ -296,7 +319,7 @@ def align(
         "edge_aware_l2",
     )
 
-    def _chunk_schedule(i: jnp.ndarray) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    def _chunk_schedule(i: jnp.ndarray) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
         i = jnp.asarray(i, dtype=jnp.int32)
         start = i * jnp.int32(chunk_size)
         remaining = jnp.maximum(0, jnp.int32(n_views) - start)
@@ -684,19 +707,19 @@ def align(
     L_prev = cfg.recon_L
     small_impr_streak = 0
     opt_mode = str(cfg.opt_method).lower()
-    outer_stats: List[Dict[str, Any]] = []
+    outer_stats: list[OuterStat] = []
     wall_start = time.perf_counter()
 
-    def _log_outer_summary(stat: Dict[str, Any]) -> None:
+    def _log_outer_summary(stat: OuterStat) -> None:
         outer_idx = int(stat.get("outer_idx", 0))
         total_iters = int(cfg.outer_iters)
         total_time = format_duration(stat.get("outer_time"))
         elapsed = format_duration(stat.get("cumulative_time"))
         if cfg.log_compact:
             # Build compact one-liner with key fields
-            parts: List[str] = [f"Outer {outer_idx}/{total_iters}"]
+            parts: list[str] = [f"Outer {outer_idx}/{total_iters}"]
             # Recon summary
-            rbits: List[str] = []
+            rbits: list[str] = []
             rt = stat.get("recon_time")
             if rt is not None:
                 rbits.append(f"{format_duration(rt)}")
@@ -714,7 +737,7 @@ def align(
             if rbits:
                 parts.append("recon " + " ".join(rbits))
             # Align summary
-            abits: List[str] = []
+            abits: list[str] = []
             at = stat.get("align_time")
             if at is not None:
                 abits.append(f"{format_duration(at)}")
@@ -744,7 +767,7 @@ def align(
             elapsed,
         )
 
-        recon_parts: List[str] = []
+        recon_parts: list[str] = []
         recon_time = stat.get("recon_time")
         if recon_time is not None:
             recon_parts.append(f"time {format_duration(recon_time)}")
@@ -764,7 +787,7 @@ def align(
                 recon_parts.append(f"loss {f_first:.3e}->{f_last:.3e}")
         logging.info("  Recon | %s", " | ".join(recon_parts) if recon_parts else "-")
 
-        align_parts: List[str] = []
+        align_parts: list[str] = []
         align_time = stat.get("align_time")
         if align_time is not None:
             align_parts.append(f"time {format_duration(align_time)}")
@@ -796,7 +819,7 @@ def align(
 
     for it in progress_iter(range(cfg.outer_iters), total=cfg.outer_iters, desc="Align: outer iters"):
         outer_idx = it + 1
-        stat: Dict[str, Any] = {"outer_idx": outer_idx}
+        stat: OuterStat = {"outer_idx": outer_idx}
         outer_start = time.perf_counter()
 
         # Reconstruction step
@@ -853,12 +876,8 @@ def align(
                     raise
             else:
                 raise
-        # Ensure device work is finished before timing recon
-        try:
-            x.block_until_ready()
-        except Exception:
-            # Fallback if x is not a DeviceArray-like object
-            jax.block_until_ready(x)
+        # Ensure device work is finished before timing recon.
+        jax.block_until_ready(x)
         recon_time = time.perf_counter() - recon_start
         stat["recon_time"] = recon_time
         stat["recon_retry"] = recon_retry
@@ -955,15 +974,8 @@ def align(
                 pass
         stat["step_kind"] = step_kind
         stat["loss_after_step"] = loss_after
-        # Ensure device work from alignment step is finished before timing
-        try:
-            # Prefer object method if available (propagates device errors correctly)
-            params5.block_until_ready()  # type: ignore[attr-defined]
-        except Exception:
-            try:
-                jax.block_until_ready(params5)
-            except Exception:
-                pass
+        # Ensure device work from alignment step is finished before timing.
+        jax.block_until_ready(params5)
         stat["align_time"] = time.perf_counter() - align_start
 
         # Track overall data loss
@@ -1079,18 +1091,18 @@ def align_multires(
     *,
     factors: Iterable[int] = (2, 1),
     cfg: AlignConfig | None = None,
-    observer: Callable[[jnp.ndarray, jnp.ndarray, Dict[str, Any]], ObserverAction | bool] | None = None,
-) -> Tuple[jnp.ndarray, jnp.ndarray, Dict]:
+    observer: ObserverCallback | None = None,
+) -> tuple[jnp.ndarray, jnp.ndarray, AlignMultiresInfo]:
     """Coarse-to-fine alignment using simple binning for speed and robustness.
 
     Carries alignment parameters across levels and downsamples/upsamples volume.
     """
-    from ..recon.multires import scale_grid, scale_detector, bin_projections, bin_volume, upsample_volume
+    from ..recon.multires import scale_grid, scale_detector, bin_projections, upsample_volume
 
     if cfg is None:
         cfg = AlignConfig()
 
-    levels: List[dict] = []
+    levels: list[MultiresLevel] = []
     for f in factors:
         levels.append(
             {
@@ -1104,7 +1116,7 @@ def align_multires(
     x_init = None
     params5 = None
     prev_factor: int | None = None
-    loss_hist: List[float] = []
+    loss_hist: list[float] = []
     stopped_by_observer = False
     final_observer_action: ObserverAction = "continue"
     global_outer_idx = 0
@@ -1139,10 +1151,7 @@ def align_multires(
                     int(cfg.recon_patience) if cfg.recon_patience is not None else 0
                 ),
             )
-            T_nom = jnp.stack(
-                [jnp.asarray(geometry.pose_for_view(i), dtype=jnp.float32) for i in range(y.shape[0])],
-                axis=0,
-            )
+            T_nom = stack_view_poses(geometry, y.shape[0])
             from ..utils.phasecorr import phase_corr_shift
             vm_pred = jax.vmap(
                 lambda T: forward_project_view_T(

--- a/src/tomojax/cli/_geometry.py
+++ b/src/tomojax/cli/_geometry.py
@@ -1,11 +1,30 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Sequence
+from typing import Sequence, TypedDict
 
 import numpy as np
 
-from ..core.geometry import Detector, Grid, LaminographyGeometry, ParallelGeometry
+from ..core.geometry import Detector, Geometry, Grid, LaminographyGeometry, ParallelGeometry
+from ..core.geometry.base import DetectorDict, GridDict, PoseMatrix, RayPair
+
+
+type JsonValue = None | bool | int | float | str | list[JsonValue] | dict[str, JsonValue]
+
+
+class LoadedGeometryMetaRequired(TypedDict):
+    detector: DetectorDict
+    thetas_deg: Sequence[float] | np.ndarray
+
+
+class LoadedGeometryMeta(LoadedGeometryMetaRequired, total=False):
+    grid: GridDict
+    geometry_type: str
+    tilt_deg: float
+    tilt_about: str
+    angle_offset_deg: np.ndarray
+    misalign_spec: dict[str, JsonValue]
+    align_params: np.ndarray
 
 
 GridOverride = Grid | tuple[int, int, int] | list[int] | None
@@ -15,16 +34,16 @@ GridOverride = Grid | tuple[int, int, int] | list[int] | None
 class AugmentedGeometry:
     """Geometry wrapper that applies saved per-view 5-DOF alignment params."""
 
-    base: Any
+    base: Geometry
     align_params: np.ndarray
 
-    def pose_for_view(self, i: int):
+    def pose_for_view(self, i: int) -> PoseMatrix:
         T_nom = np.asarray(self.base.pose_for_view(i), dtype=np.float32)
         T_delta = _se3_from_5d_np(self.align_params[i])
         T = T_nom @ T_delta
         return tuple(map(tuple, T))
 
-    def rays_for_view(self, i: int):
+    def rays_for_view(self, i: int) -> RayPair:
         return self.base.rays_for_view(i)
 
 
@@ -61,15 +80,23 @@ def _se3_from_5d_np(params5: np.ndarray) -> np.ndarray:
     return T
 
 
-def _detector_from_meta(meta: dict) -> Detector:
+def _detector_from_meta(meta: LoadedGeometryMeta) -> Detector:
     det_d = meta["detector"]
+    det_center = det_d.get("det_center", [0.0, 0.0])
     return Detector(
-        **{k: det_d[k] for k in ("nu", "nv", "du", "dv")},
-        det_center=tuple(det_d.get("det_center", (0.0, 0.0))),
+        nu=int(det_d["nu"]),
+        nv=int(det_d["nv"]),
+        du=float(det_d["du"]),
+        dv=float(det_d["dv"]),
+        det_center=(float(det_center[0]), float(det_center[1])),
     )
 
 
-def _grid_from_meta(meta: dict, detector: Detector, grid_override: GridOverride) -> Grid:
+def _grid_from_meta(
+    meta: LoadedGeometryMeta,
+    detector: Detector,
+    grid_override: GridOverride,
+) -> Grid:
     if isinstance(grid_override, Grid):
         return grid_override
 
@@ -90,33 +117,47 @@ def _grid_from_meta(meta: dict, detector: Detector, grid_override: GridOverride)
             vz=float(detector.dv),
         )
 
+    vol_origin = (
+        tuple(float(v) for v in grid_d["vol_origin"])
+        if grid_d.get("vol_origin") is not None
+        else None
+    )
+    vol_center = (
+        tuple(float(v) for v in grid_d["vol_center"])
+        if grid_d.get("vol_center") is not None
+        else None
+    )
+
     if grid_override is not None:
         nx, ny, nz = map(int, grid_override)
-        kwargs: dict[str, Any] = {
-            "nx": nx,
-            "ny": ny,
-            "nz": nz,
-            "vx": float(grid_d["vx"]),
-            "vy": float(grid_d["vy"]),
-            "vz": float(grid_d["vz"]),
-        }
-        if grid_d.get("vol_origin") is not None:
-            kwargs["vol_origin"] = tuple(grid_d["vol_origin"])
-        if grid_d.get("vol_center") is not None:
-            kwargs["vol_center"] = tuple(grid_d["vol_center"])
-        return Grid(**kwargs)
+        return Grid(
+            nx=nx,
+            ny=ny,
+            nz=nz,
+            vx=float(grid_d["vx"]),
+            vy=float(grid_d["vy"]),
+            vz=float(grid_d["vz"]),
+            vol_origin=vol_origin,
+            vol_center=vol_center,
+        )
 
-    kwargs: dict[str, Any] = {
-        k: grid_d[k] for k in ("nx", "ny", "nz", "vx", "vy", "vz")
-    }
-    if grid_d.get("vol_origin") is not None:
-        kwargs["vol_origin"] = tuple(grid_d["vol_origin"])
-    if grid_d.get("vol_center") is not None:
-        kwargs["vol_center"] = tuple(grid_d["vol_center"])
-    return Grid(**kwargs)
+    return Grid(
+        nx=int(grid_d["nx"]),
+        ny=int(grid_d["ny"]),
+        nz=int(grid_d["nz"]),
+        vx=float(grid_d["vx"]),
+        vy=float(grid_d["vy"]),
+        vz=float(grid_d["vz"]),
+        vol_origin=vol_origin,
+        vol_center=vol_center,
+    )
 
 
-def _resolve_thetas_deg(meta: dict, *, apply_saved_angle_offset: bool) -> np.ndarray:
+def _resolve_thetas_deg(
+    meta: LoadedGeometryMeta,
+    *,
+    apply_saved_angle_offset: bool,
+) -> np.ndarray:
     thetas = np.asarray(meta["thetas_deg"], dtype=np.float32)
     if not apply_saved_angle_offset:
         return thetas
@@ -141,11 +182,11 @@ def _resolve_thetas_deg(meta: dict, *, apply_saved_angle_offset: bool) -> np.nda
 
 def _base_geometry(
     *,
-    meta: dict,
+    meta: LoadedGeometryMeta,
     grid: Grid,
     detector: Detector,
     thetas_deg: Sequence[float],
-):
+) -> Geometry:
     gtype = meta.get("geometry_type", "parallel")
     if gtype == "parallel":
         return ParallelGeometry(grid=grid, detector=detector, thetas_deg=thetas_deg)
@@ -162,11 +203,11 @@ def _base_geometry(
 
 
 def build_geometry_from_meta(
-    meta: dict,
+    meta: LoadedGeometryMeta,
     *,
     grid_override: GridOverride = None,
     apply_saved_alignment: bool = False,
-) -> tuple[Grid, Detector, Any]:
+) -> tuple[Grid, Detector, Geometry]:
     """Build geometry from NXtomo metadata with sensible fallbacks.
 
     When `grid` metadata is missing, the grid is inferred from detector dimensions
@@ -204,9 +245,9 @@ def build_geometry_from_meta(
 
 
 def build_nominal_geometry_from_meta(
-    meta: dict,
+    meta: LoadedGeometryMeta,
     grid_override: GridOverride = None,
-) -> tuple[Grid, Detector, Any]:
+) -> tuple[Grid, Detector, Geometry]:
     """Build geometry without composing any saved alignment metadata."""
     return build_geometry_from_meta(
         meta,

--- a/src/tomojax/cli/align.py
+++ b/src/tomojax/cli/align.py
@@ -224,7 +224,6 @@ def main() -> None:
         default=[],
         help="Loss parameter as k=v (repeatable), e.g., delta=1.0, eps=1e-3, window=7, temp=0.5",
     )
-    # (LBFGS options removed)
     # Early stopping controls (alignment phase)
     es = p.add_mutually_exclusive_group()
     es.add_argument(

--- a/src/tomojax/cli/loss_bench.py
+++ b/src/tomojax/cli/loss_bench.py
@@ -16,9 +16,13 @@ from ..data.simulate import SimConfig, simulate_to_file
 from ..data.io_hdf5 import load_nxtomo, save_nxtomo
 from ..align.pipeline import align, AlignConfig
 from ..core.geometry import Grid, Detector, ParallelGeometry, LaminographyGeometry
+from ..core.geometry.views import stack_view_poses
 from ..core.projector import forward_project_view_T, get_detector_grid_device
 from ..align.parametrizations import se3_from_5d
 from ..utils.logging import setup_logging, log_jax_env
+
+
+type BenchmarkResultValue = str | float | None
 
 
 def _ensure_dir(p: str) -> None:
@@ -100,9 +104,7 @@ def _make_misaligned_dataset(
         np.float32
     ) * float(det.dv)
     params5_j = jnp.asarray(params5, jnp.float32)
-    T_nom = jnp.stack(
-        [jnp.asarray(geom.pose_for_view(i), jnp.float32) for i in range(n)], axis=0
-    )
+    T_nom = stack_view_poses(geom, n)
     T_aug = T_nom @ jax.vmap(se3_from_5d)(params5_j)
     det_grid = get_detector_grid_device(det)
     vm_project = jax.vmap(
@@ -284,10 +286,7 @@ def _gt_projection_mse(
     Uses current process device; modest sizes recommended.
     """
     thetas = np.asarray(geom.thetas_deg, dtype=np.float32)
-    T_nom = jnp.stack(
-        [jnp.asarray(geom.pose_for_view(i), jnp.float32) for i in range(len(thetas))],
-        axis=0,
-    )
+    T_nom = stack_view_poses(geom, len(thetas))
     S_est = jax.vmap(se3_from_5d)(jnp.asarray(params_est, jnp.float32))
     T_est_full = T_nom @ S_est
     det_grid = get_detector_grid_device(det)
@@ -441,10 +440,9 @@ def main() -> None:
         "edge_l2": 5e-2,
         "pwls": 5e-2,
     }
-    # LBFGS removed
 
     # 4) Run alignment for each loss or load existing outputs
-    results: List[Dict[str, object]] = []
+    results: list[dict[str, BenchmarkResultValue]] = []
     for loss in args.losses:
         run_name = str(loss).lower()
         out_path = os.path.join(args.expdir, f"align_{run_name}.nxs")
@@ -464,7 +462,7 @@ def main() -> None:
         start = time.perf_counter()
         status = "ok"
         err_msg = None
-        metrics: Dict[str, float] = {}
+        metrics: dict[str, float] = {}
         try:
             p_est_np: np.ndarray
             x_est_np: np.ndarray | None = None
@@ -475,7 +473,6 @@ def main() -> None:
                 )
                 meta_out = load_nxtomo(out_path)
                 p_est_np = np.asarray(meta_out.get("align_params"), dtype=np.float32)
-                # prefer saved recon if present for possible future metrics
                 x_est_np = (
                     np.asarray(meta_out.get("volume"))
                     if meta_out.get("volume") is not None

--- a/src/tomojax/cli/misalign.py
+++ b/src/tomojax/cli/misalign.py
@@ -9,19 +9,11 @@ import jax.numpy as jnp
 
 from ..data.io_hdf5 import load_nxtomo, save_nxtomo
 from ..core.geometry import Grid, Detector, ParallelGeometry, LaminographyGeometry
+from ..core.geometry.views import stack_view_poses
 from ..align.parametrizations import se3_from_5d
 from ..core.projector import forward_project_view_T
 from ..utils.logging import setup_logging, log_jax_env
 from ._runtime import transfer_guard_context
-
-
-def _parse_bool(s: str) -> bool:
-    s = s.strip().lower()
-    if s in ("1", "true", "yes", "y", "on"):
-        return True
-    if s in ("0", "false", "no", "n", "off"):
-        return False
-    raise ValueError(f"Invalid boolean value: {s}")
 
 
 def _parse_number_with_unit(val: str) -> tuple[float, str | None]:
@@ -472,10 +464,7 @@ def main() -> None:
         )
 
     # Recompute nominal poses with final geometry (possibly modified angles)
-    T_nom = jnp.stack(
-        [jnp.asarray(geom.pose_for_view(i), jnp.float32) for i in range(n_views)],
-        axis=0,
-    )
+    T_nom = stack_view_poses(geom, n_views)
     params5 = jnp.asarray(params5_np, jnp.float32)
 
     with transfer_guard_context(args.transfer_guard):

--- a/src/tomojax/cli/recon.py
+++ b/src/tomojax/cli/recon.py
@@ -340,10 +340,8 @@ def main() -> None:
                 config=cfg,
             )
 
-    # Note: Reconstructions are computed on the object (sample) frame. We persist that by default.
-    # If a lab-frame export is desired, we currently only record metadata; a resampling export
-    # may be added later if needed for interop.
-    # Avoid copying projections back from device: reuse host array from metadata
+    # Save the reconstruction in the object (sample) frame.
+    # Reuse host projections from metadata to avoid a device-to-host copy.
     save_nxtomo(
         args.out,
         projections=meta["projections"],

--- a/src/tomojax/core/geometry/base.py
+++ b/src/tomojax/core/geometry/base.py
@@ -7,7 +7,36 @@ them lightweight and JAX-friendly (no heavy runtime logic here).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Callable, Iterable, Protocol, Tuple
+from typing import Callable, Iterable, Protocol, TypedDict
+
+
+Vec2 = tuple[float, float]
+Vec3 = tuple[float, float, float]
+PoseMatrix = tuple[tuple[float, ...], ...]
+RayFunction = Callable[[int, int], Vec3]
+RayPair = tuple[RayFunction, RayFunction]
+
+
+class GridDictRequired(TypedDict):
+    nx: int
+    ny: int
+    nz: int
+    vx: float
+    vy: float
+    vz: float
+
+
+class GridDict(GridDictRequired, total=False):
+    vol_origin: list[float]
+    vol_center: list[float]
+
+
+class DetectorDict(TypedDict):
+    nu: int
+    nv: int
+    du: float
+    dv: float
+    det_center: list[float]
 
 
 def _coerce_fixed_tuple(name: str, value: Iterable[float], expected_len: int) -> tuple[float, ...]:
@@ -38,8 +67,8 @@ class Grid:
     vx: float
     vy: float
     vz: float
-    vol_origin: Tuple[float, float, float] | None = None
-    vol_center: Tuple[float, float, float] | None = None
+    vol_origin: Vec3 | None = None
+    vol_center: Vec3 | None = None
 
     def __post_init__(self) -> None:
         if self.vol_origin is not None:
@@ -55,7 +84,7 @@ class Grid:
                 _coerce_fixed_tuple("vol_center", self.vol_center, 3),
             )
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> GridDict:
         d = {
             "nx": int(self.nx),
             "ny": int(self.ny),
@@ -77,7 +106,7 @@ class Detector:
     nv: int
     du: float
     dv: float
-    det_center: Tuple[float, float] = field(default_factory=lambda: (0.0, 0.0))
+    det_center: Vec2 = field(default_factory=lambda: (0.0, 0.0))
 
     def __post_init__(self) -> None:
         object.__setattr__(
@@ -86,7 +115,7 @@ class Detector:
             _coerce_fixed_tuple("det_center", self.det_center, 2),
         )
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> DetectorDict:
         return {
             "nu": int(self.nu),
             "nv": int(self.nv),
@@ -94,6 +123,32 @@ class Detector:
             "dv": float(self.dv),
             "det_center": list(self.det_center),
         }
+
+
+def _parallel_detector_rays(
+    grid: Grid,
+    detector: Detector,
+) -> RayPair:
+    """Return the standard detector-plane ray model used by parallel-beam setups."""
+    nu, nv = int(detector.nu), int(detector.nv)
+    du, dv = float(detector.du), float(detector.dv)
+    cx, cz = float(detector.det_center[0]), float(detector.det_center[1])
+
+    y0 = (
+        float(grid.vol_origin[1])
+        if grid.vol_origin is not None
+        else -((grid.ny / 2.0) - 0.5) * float(grid.vy)
+    )
+
+    def origin_fn(u: int, v: int) -> Vec3:
+        x = (u - (nu / 2.0 - 0.5)) * du + cx
+        z = (v - (nv / 2.0 - 0.5)) * dv + cz
+        return float(x), float(y0), float(z)
+
+    def dir_fn(u: int, v: int) -> Vec3:
+        return (0.0, 1.0, 0.0)
+
+    return origin_fn, dir_fn
 
 
 class Geometry(Protocol):
@@ -104,13 +159,10 @@ class Geometry(Protocol):
     for the projector; rays_for_view(i) must define world-frame rays.
     """
 
-    def pose_for_view(self, i: int) -> Tuple[Tuple[float, ...], ...]:
+    def pose_for_view(self, i: int) -> PoseMatrix:
         """Returns a 4x4 homogeneous transform world_from_object (row-major)."""
 
-    def rays_for_view(self, i: int) -> Tuple[
-        Callable[[int, int], Tuple[float, float, float]],
-        Callable[[int, int], Tuple[float, float, float]],
-    ]:
+    def rays_for_view(self, i: int) -> RayPair:
         """Returns (origin_fn, dir_fn) that map detector pixel (u,v) to a ray.
 
         origin_fn(u,v) -> (x,y,z); dir_fn(u,v) -> (dx,dy,dz) normalized.

--- a/src/tomojax/core/geometry/lamino.py
+++ b/src/tomojax/core/geometry/lamino.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Tuple, Sequence
+from typing import Sequence
 
 import numpy as np
 
-from .base import Grid, Detector, Geometry
+from .base import Detector, Grid, PoseMatrix, RayPair, _parallel_detector_rays
 from .transforms import rot_axis_angle
 
 
@@ -79,7 +79,7 @@ class LaminographyGeometry:
     def _axis_unit(self) -> np.ndarray:
         return laminography_axis_unit(self.tilt_deg, self.tilt_about)
 
-    def pose_for_view(self, i: int):
+    def pose_for_view(self, i: int) -> PoseMatrix:
         """World-from-object pose in sample frame; rotation about object +y.
 
         We align the object's +y axis to the laminography axis once via S, then
@@ -96,24 +96,6 @@ class LaminographyGeometry:
         T[:3, :3] = R
         return tuple(map(tuple, T))  # 4x4
 
-    def rays_for_view(self, i: int):
-        # Same detector plane and beam direction as parallel CT for now
-        nu, nv = int(self.detector.nu), int(self.detector.nv)
-        du, dv = float(self.detector.du), float(self.detector.dv)
-        cx, cz = float(self.detector.det_center[0]), float(self.detector.det_center[1])
-
-        y0 = (
-            float(self.grid.vol_origin[1])
-            if self.grid.vol_origin is not None
-            else -((self.grid.ny / 2.0) - 0.5) * float(self.grid.vy)
-        )
-
-        def origin_fn(u: int, v: int) -> Tuple[float, float, float]:
-            x = (u - (nu / 2.0 - 0.5)) * du + cx
-            z = (v - (nv / 2.0 - 0.5)) * dv + cz
-            return float(x), float(y0), float(z)
-
-        def dir_fn(u: int, v: int) -> Tuple[float, float, float]:
-            return (0.0, 1.0, 0.0)
-
-        return origin_fn, dir_fn
+    def rays_for_view(self, i: int) -> RayPair:
+        # Use the same detector plane and beam direction as parallel CT.
+        return _parallel_detector_rays(self.grid, self.detector)

--- a/src/tomojax/core/geometry/parallel.py
+++ b/src/tomojax/core/geometry/parallel.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Tuple, Sequence
+from typing import Sequence
 
 import numpy as np
 
-from .base import Grid, Detector, Geometry
+from .base import Detector, Grid, PoseMatrix, RayPair, _parallel_detector_rays
 from .transforms import rotz
 
 
@@ -22,28 +22,10 @@ class ParallelGeometry:
     detector: Detector
     thetas_deg: Sequence[float]
 
-    def pose_for_view(self, i: int) -> Tuple[Tuple[float, ...], ...]:
+    def pose_for_view(self, i: int) -> PoseMatrix:
         phi = float(np.deg2rad(self.thetas_deg[i]))
         T = rotz(phi)
         return tuple(map(tuple, T))  # 4x4
 
-    def rays_for_view(self, i: int):
-        nu, nv = int(self.detector.nu), int(self.detector.nv)
-        du, dv = float(self.detector.du), float(self.detector.dv)
-        cx, cz = float(self.detector.det_center[0]), float(self.detector.det_center[1])
-
-        y0 = (
-            float(self.grid.vol_origin[1])
-            if self.grid.vol_origin is not None
-            else -((self.grid.ny / 2.0) - 0.5) * float(self.grid.vy)
-        )
-
-        def origin_fn(u: int, v: int) -> Tuple[float, float, float]:
-            x = (u - (nu / 2.0 - 0.5)) * du + cx
-            z = (v - (nv / 2.0 - 0.5)) * dv + cz
-            return float(x), float(y0), float(z)
-
-        def dir_fn(u: int, v: int) -> Tuple[float, float, float]:
-            return (0.0, 1.0, 0.0)
-
-        return origin_fn, dir_fn
+    def rays_for_view(self, i: int) -> RayPair:
+        return _parallel_detector_rays(self.grid, self.detector)

--- a/src/tomojax/core/geometry/views.py
+++ b/src/tomojax/core/geometry/views.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import jax.numpy as jnp
+
+from .base import Geometry
+
+
+def stack_view_poses(
+    geometry: Geometry,
+    n_views: int,
+    *,
+    dtype: jnp.dtype = jnp.float32,
+) -> jnp.ndarray:
+    return jnp.stack(
+        [jnp.asarray(geometry.pose_for_view(i), dtype=dtype) for i in range(int(n_views))],
+        axis=0,
+    )

--- a/src/tomojax/data/contrast.py
+++ b/src/tomojax/data/contrast.py
@@ -14,12 +14,7 @@ try:  # pragma: no cover - optional JAX dependency
     import jax  # type: ignore
     import jax.numpy as _jnp  # type: ignore
 
-    if hasattr(jax, "Array"):
-        _JAX_ARRAY_TYPES = (jax.Array,)  # type: ignore[attr-defined]
-    else:  # Fallback for older JAX versions
-        from jax.interpreters.xla import DeviceArray as _DeviceArray  # type: ignore
-
-        _JAX_ARRAY_TYPES = (_DeviceArray,)  # type: ignore[assignment]
+    _JAX_ARRAY_TYPES = (jax.Array,)  # type: ignore[attr-defined]
 except Exception:  # pragma: no cover - no JAX installed
     _jnp = None  # type: ignore
     _JAX_ARRAY_TYPES: tuple[type, ...] = ()

--- a/src/tomojax/data/datasets.py
+++ b/src/tomojax/data/datasets.py
@@ -1,33 +1,36 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+import numpy as np
 
 from .io_hdf5 import (
+    DatasetValue,
+    LoadedDataset,
+    ValidationReport,
     load_nxtomo,
-    save_nxtomo,
-    validate_nxtomo,
     load_npz,
+    save_nxtomo,
     save_npz,
+    validate_nxtomo,
 )
 
 
-def load_dataset(path: str) -> Dict[str, Any]:
+def load_dataset(path: str) -> LoadedDataset:
     if path.endswith(".npz"):
         return load_npz(path)
     return load_nxtomo(path)
 
 
-def save_dataset(path: str, projections, **meta) -> None:
+def save_dataset(path: str, projections: np.ndarray, **meta: DatasetValue) -> None:
     if path.endswith(".npz"):
         return save_npz(path, projections=projections, **meta)
     return save_nxtomo(path, projections, **meta)
 
 
-def validate_dataset(path: str) -> Dict[str, Any]:
+def validate_dataset(path: str) -> ValidationReport:
     if path.endswith(".npz"):
         # NPZ: minimal validation
         data = load_npz(path)
-        issues = []
+        issues: list[str] = []
         if "projections" not in data:
             issues.append("missing 'projections' array in .npz")
         return {"issues": issues}

--- a/src/tomojax/data/io_hdf5.py
+++ b/src/tomojax/data/io_hdf5.py
@@ -12,12 +12,12 @@ from __future__ import annotations
 import json
 import logging
 import os
-from typing import Any, Dict, Optional
+from typing import TypedDict
 
-import numpy as np
 import h5py
+import numpy as np
 
-from ..core.geometry.base import Grid, Detector
+from ..core.geometry.base import Detector, DetectorDict, Grid, GridDict
 from ..utils.axes import (
     DISK_VOLUME_AXES,
     INTERNAL_VOLUME_AXES,
@@ -36,13 +36,30 @@ _AXES_SILENCE = os.environ.get("TOMOJAX_AXES_SILENCE", "").lower() in {
     "on",
 }
 
+type JsonValue = None | bool | int | float | str | list[JsonValue] | dict[str, JsonValue]
+type JsonObject = dict[str, JsonValue]
+class SourceInfo(TypedDict, total=False):
+    name: str | None
+    type: str | None
+    probe: str | None
 
-def _axes_log_warning(message: str, *args: Any) -> None:
+
+type DatasetValue = (
+    np.ndarray | JsonValue | GridDict | DetectorDict | SourceInfo
+)
+type LoadedDataset = dict[str, DatasetValue]
+
+
+class ValidationReport(TypedDict):
+    issues: list[str]
+
+
+def _axes_log_warning(message: str, *args: object) -> None:
     if not _AXES_SILENCE:
         LOG.warning(message, *args)
 
 
-def _attr_to_str(v: Any, default: str | None = None) -> str | None:
+def _attr_to_str(v: object, default: str | None = None) -> str | None:
     """Robustly convert an HDF5 attribute to a Python string.
 
     Handles h5py special string dtypes, numpy scalars/arrays, bytes, and plain str.
@@ -65,7 +82,7 @@ def _attr_to_str(v: Any, default: str | None = None) -> str | None:
 
 
 def _ensure_group(
-    root: h5py.Group, name: str, nx_class: Optional[str] = None
+    root: h5py.Group, name: str, nx_class: str | None = None
 ) -> h5py.Group:
     g = root.require_group(name)
     if nx_class:
@@ -81,21 +98,21 @@ def save_nxtomo(
     path: str,
     projections: np.ndarray,
     *,
-    thetas_deg: Optional[np.ndarray] = None,
-    image_key: Optional[np.ndarray] = None,
-    grid: Optional[Grid | Dict[str, Any]] = None,
-    detector: Optional[Detector | Dict[str, Any]] = None,
+    thetas_deg: np.ndarray | None = None,
+    image_key: np.ndarray | None = None,
+    grid: Grid | GridDict | None = None,
+    detector: Detector | DetectorDict | None = None,
     geometry_type: str = "parallel",
-    geometry_meta: Optional[Dict[str, Any]] = None,
-    volume: Optional[np.ndarray] = None,
-    align_params: Optional[np.ndarray] = None,
-    angle_offset_deg: Optional[np.ndarray] = None,
-    misalign_spec: Optional[Dict[str, Any]] = None,
-    frame: Optional[str] = None,
-    sample_name: Optional[str] = "sample",
-    source_name: Optional[str] = "TomoJAX source",
-    source_type: Optional[str] = None,
-    source_probe: Optional[str] = "x-ray",
+    geometry_meta: JsonObject | None = None,
+    volume: np.ndarray | None = None,
+    align_params: np.ndarray | None = None,
+    angle_offset_deg: np.ndarray | None = None,
+    misalign_spec: JsonObject | None = None,
+    frame: str | None = None,
+    sample_name: str | None = "sample",
+    source_name: str | None = "TomoJAX source",
+    source_type: str | None = None,
+    source_probe: str | None = "x-ray",
     compression: str = "lzf",
     overwrite: bool = True,
     volume_axes_order: str = DISK_VOLUME_AXES,
@@ -166,10 +183,8 @@ def save_nxtomo(
         det.create_dataset("image_key", data=im_key, dtype=np.int32)
 
         # Pixel geometry if provided
-        det_meta: Dict[str, Any] = {}
         if detector is not None:
             det_dict = detector if isinstance(detector, dict) else detector.to_dict()
-            det_meta = det_dict
             det.attrs["detector_meta_json"] = json.dumps(det_dict)
             # Store basic pixel sizes (units arbitrary for sims)
             det.create_dataset("x_pixel_size", data=np.asarray(det_dict.get("du", 1.0)))
@@ -230,10 +245,8 @@ def save_nxtomo(
             )
 
         # Grid metadata
-        grid_meta: Dict[str, Any] = {}
         if grid is not None:
             gdict = grid if isinstance(grid, dict) else grid.to_dict()
-            grid_meta = gdict
             entry.attrs["grid_meta_json"] = json.dumps(gdict)
 
         # Optional GT / reconstructed volume and TomoJAX metadata
@@ -289,15 +302,15 @@ def save_nxtomo(
                 align_grp.attrs["misalign_spec_json"] = json.dumps(misalign_spec)
 
 
-def load_nxtomo(path: str) -> Dict[str, Any]:
+def load_nxtomo(path: str) -> LoadedDataset:
     """Load an NXtomo dataset and TomoJAX extras.
 
     Returns a dict with keys: projections, thetas_deg, geometry_type, grid, detector,
     and optional volume, align_params. Volumes are returned in internal `xyz` order.
     """
-    out: Dict[str, Any] = {}
-    volume_raw: Optional[np.ndarray] = None
-    volume_axes_attr: Optional[str] = None
+    out: LoadedDataset = {}
+    volume_raw: np.ndarray | None = None
+    volume_axes_attr: str | None = None
 
     with h5py.File(path, "r") as f:
         entry = f["/entry"]
@@ -386,7 +399,7 @@ def load_nxtomo(path: str) -> Dict[str, Any]:
             if inst_grp is not None:
                 source_grp = inst_grp.get("SOURCE") or inst_grp.get("source")
             if source_grp is not None:
-                source_info: Dict[str, Any] = {}
+                source_info: SourceInfo = {}
                 for key in ("name", "type", "probe"):
                     if key in source_grp:
                         source_info[key] = _attr_to_str(source_grp[key][()])
@@ -509,9 +522,9 @@ def load_nxtomo(path: str) -> Dict[str, Any]:
     return out
 
 
-def validate_nxtomo(path: str) -> Dict[str, Any]:
+def validate_nxtomo(path: str) -> ValidationReport:
     """Lightweight schema checks. Returns a report dict; empty `issues` means OK."""
-    report: Dict[str, Any] = {"issues": []}
+    report: ValidationReport = {"issues": []}
     try:
         with h5py.File(path, "r") as f:
             if "/entry" not in f:
@@ -570,14 +583,14 @@ def validate_nxtomo(path: str) -> Dict[str, Any]:
     return report
 
 
-def save_npz(path: str, projections: np.ndarray, **meta: Any) -> None:
+def save_npz(path: str, projections: np.ndarray, **meta: DatasetValue) -> None:
     """Simple NPZ saver for tiny tests or interop."""
     np.savez_compressed(path, projections=projections, **meta)
 
 
-def load_npz(path: str) -> Dict[str, Any]:
+def load_npz(path: str) -> LoadedDataset:
     with np.load(path, allow_pickle=True) as z:
-        out: Dict[str, Any] = {}
+        out: LoadedDataset = {}
         for k in z.files:
             val = z[k]
             if isinstance(val, np.ndarray) and val.shape == () and val.dtype == object:

--- a/src/tomojax/data/simulate.py
+++ b/src/tomojax/data/simulate.py
@@ -1,31 +1,55 @@
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
-from typing import Dict
+from typing import Literal, TypedDict
 
-import numpy as np
-import jax.numpy as jnp
 import jax
+import jax.numpy as jnp
+import numpy as np
 
-from ..core.geometry import Grid, Detector, ParallelGeometry, LaminographyGeometry
+from ..core.geometry import Detector, Grid, LaminographyGeometry, ParallelGeometry
+from ..core.geometry.base import DetectorDict, GridDict
+from ..core.geometry.views import stack_view_poses
 from ..core.projector import (
     forward_project_view,
     forward_project_view_T,
     get_detector_grid_device,
 )
-from ..utils.logging import progress_iter
+from ..utils.memory import default_gather_dtype
 from .phantoms import (
-    cube,
-    rotated_centered_cube,
-    sphere,
     blobs,
-    shepp_logan_3d,
-    random_cubes_spheres,
+    cube,
     lamino_disk,
+    random_cubes_spheres,
+    rotated_centered_cube,
+    shepp_logan_3d,
+    sphere,
 )
 from .io_hdf5 import save_nxtomo
-from ..utils.memory import default_gather_dtype
-import os
+from ..utils.logging import progress_iter
+
+
+class LaminoGeometryMeta(TypedDict):
+    tilt_deg: float
+    tilt_about: str
+
+
+class SimMetadata(TypedDict):
+    seed: int
+    noise: str
+    noise_level: float
+
+
+class SimulatedData(TypedDict):
+    projections: jnp.ndarray
+    thetas_deg: np.ndarray
+    grid: GridDict
+    detector: DetectorDict
+    geometry_type: Literal["parallel", "lamino"]
+    volume: jnp.ndarray
+    geometry_meta: LaminoGeometryMeta | None
+    meta: SimMetadata
 
 
 @dataclass
@@ -134,7 +158,7 @@ def make_phantom(cfg: SimConfig) -> jnp.ndarray:
     return jnp.asarray(vol, dtype=jnp.float32)
 
 
-def simulate(cfg: SimConfig) -> Dict[str, object]:
+def simulate(cfg: SimConfig) -> SimulatedData:
     grid = Grid(cfg.nx, cfg.ny, cfg.nz, cfg.vx, cfg.vy, cfg.vz)
     det = Detector(cfg.nu, cfg.nv, cfg.du, cfg.dv, det_center=(0.0, 0.0))
     # Determine total rotation based on geometry unless overridden
@@ -144,10 +168,12 @@ def simulate(cfg: SimConfig) -> Dict[str, object]:
         total_deg = 180.0 if cfg.geometry == "parallel" else 360.0
     thetas = np.linspace(0.0, total_deg, cfg.n_views, endpoint=False).astype(np.float32)
 
-    geometry_meta: Dict[str, object] | None = None
+    geometry_meta: LaminoGeometryMeta | None = None
     if cfg.geometry == "parallel":
+        geometry_type: Literal["parallel", "lamino"] = "parallel"
         geom = ParallelGeometry(grid=grid, detector=det, thetas_deg=thetas)
     elif cfg.geometry == "lamino":
+        geometry_type = "lamino"
         geom = LaminographyGeometry(
             grid=grid,
             detector=det,
@@ -168,10 +194,7 @@ def simulate(cfg: SimConfig) -> Dict[str, object]:
     gather = default_gather_dtype()
 
     # Fast path: build all poses and optionally vmapped/jitted projector
-    T_all = jnp.stack(
-        [jnp.asarray(geom.pose_for_view(i), jnp.float32) for i in range(cfg.n_views)],
-        axis=0,
-    )
+    T_all = stack_view_poses(geom, cfg.n_views)
     det_grid = get_detector_grid_device(det)
 
     use_fast = (cfg.n_views >= 8) and (os.environ.get("TOMOJAX_PROGRESS", "0") != "1")
@@ -219,7 +242,7 @@ def simulate(cfg: SimConfig) -> Dict[str, object]:
         "thetas_deg": thetas,
         "grid": grid.to_dict(),
         "detector": det.to_dict(),
-        "geometry_type": cfg.geometry,
+        "geometry_type": geometry_type,
         "volume": vol,
         "geometry_meta": geometry_meta,
         "meta": {"seed": cfg.seed, "noise": cfg.noise, "noise_level": cfg.noise_level},

--- a/src/tomojax/recon/_tv_ops.py
+++ b/src/tomojax/recon/_tv_ops.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import jax.numpy as jnp
+
+
+def grad3(u: jnp.ndarray):
+    dx = jnp.concatenate(
+        [jnp.diff(u, axis=0), jnp.zeros((1, u.shape[1], u.shape[2]), u.dtype)],
+        axis=0,
+    )
+    dy = jnp.concatenate(
+        [jnp.diff(u, axis=1), jnp.zeros((u.shape[0], 1, u.shape[2]), u.dtype)],
+        axis=1,
+    )
+    dz = jnp.concatenate(
+        [jnp.diff(u, axis=2), jnp.zeros((u.shape[0], u.shape[1], 1), u.dtype)],
+        axis=2,
+    )
+    return dx, dy, dz
+
+
+def div3(px: jnp.ndarray, py: jnp.ndarray, pz: jnp.ndarray):
+    """Discrete divergence matching the TV updates: ``div3 = -grad3*``."""
+    if px.shape[0] == 1:
+        dx = jnp.zeros_like(px)
+    else:
+        first_x = px[0:1, :, :]
+        if px.shape[0] > 2:
+            mid_x = px[1:-1, :, :] - px[0:-2, :, :]
+            dx = jnp.concatenate([first_x, mid_x, -px[-2:-1, :, :]], axis=0)
+        else:
+            dx = jnp.concatenate([first_x, -px[-2:-1, :, :]], axis=0)
+
+    if py.shape[1] == 1:
+        dy = jnp.zeros_like(py)
+    else:
+        first_y = py[:, 0:1, :]
+        if py.shape[1] > 2:
+            mid_y = py[:, 1:-1, :] - py[:, 0:-2, :]
+            dy = jnp.concatenate([first_y, mid_y, -py[:, -2:-1, :]], axis=1)
+        else:
+            dy = jnp.concatenate([first_y, -py[:, -2:-1, :]], axis=1)
+
+    if pz.shape[2] == 1:
+        dz = jnp.zeros_like(pz)
+    else:
+        first_z = pz[:, :, 0:1]
+        if pz.shape[2] > 2:
+            mid_z = pz[:, :, 1:-1] - pz[:, :, 0:-2]
+            dz = jnp.concatenate([first_z, mid_z, -pz[:, :, -2:-1]], axis=2)
+        else:
+            dz = jnp.concatenate([first_z, -pz[:, :, -2:-1]], axis=2)
+    return dx + dy + dz

--- a/src/tomojax/recon/fbp.py
+++ b/src/tomojax/recon/fbp.py
@@ -7,7 +7,8 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 
-from ..core.geometry import Grid, Detector, Geometry
+from ..core.geometry.base import Grid, Detector, Geometry
+from ..core.geometry.views import stack_view_poses
 from ..core.projector import backproject_view_T
 from .filters import get_filter_np
 from ..utils.logging import progress_iter
@@ -291,10 +292,7 @@ def fbp(
     proj = jnp.asarray(projections, dtype=jnp.float32)
     n_views, nv, nu = proj.shape
     # Precompute poses once
-    T_all = jnp.stack(
-        [jnp.asarray(geometry.pose_for_view(i), dtype=jnp.float32) for i in range(n_views)],
-        axis=0,
-    )
+    T_all = stack_view_poses(geometry, n_views)
     requested_b = int(views_per_batch) if int(views_per_batch) > 0 else n_views
     b = max(1, min(requested_b, n_views))
     view_progress = iter(progress_iter(range(n_views), total=n_views, desc="FBP: views"))

--- a/src/tomojax/recon/fista_tv.py
+++ b/src/tomojax/recon/fista_tv.py
@@ -6,55 +6,18 @@ from typing import Callable, Literal, Tuple, Optional
 import jax
 import jax.numpy as jnp
 
-from ..core.geometry import Geometry, Grid, Detector
+from ..core.geometry.base import Geometry, Grid, Detector
+from ..core.geometry.views import stack_view_poses
 from ..core.projector import (
     _sum_backproject_views_T,
     backproject_view_T,
     forward_project_view_T,
     get_detector_grid_device,
 )
+from ._tv_ops import div3, grad3
 
 
-
-def _grad3(u: jnp.ndarray):
-    dx = jnp.concatenate([jnp.diff(u, axis=0), jnp.zeros((1, u.shape[1], u.shape[2]), u.dtype)], axis=0)
-    dy = jnp.concatenate([jnp.diff(u, axis=1), jnp.zeros((u.shape[0], 1, u.shape[2]), u.dtype)], axis=1)
-    dz = jnp.concatenate([jnp.diff(u, axis=2), jnp.zeros((u.shape[0], u.shape[1], 1), u.dtype)], axis=2)
-    return dx, dy, dz
-
-
-def _div3(px: jnp.ndarray, py: jnp.ndarray, pz: jnp.ndarray):
-    """Discrete divergence matching the TV updates: ``_div3 = -_grad3*``."""
-    if px.shape[0] == 1:
-        dx = jnp.zeros_like(px)
-    else:
-        first_x = px[0:1, :, :]
-        if px.shape[0] > 2:
-            mid_x = px[1:-1, :, :] - px[0:-2, :, :]
-            dx = jnp.concatenate([first_x, mid_x, -px[-2:-1, :, :]], axis=0)
-        else:
-            dx = jnp.concatenate([first_x, -px[-2:-1, :, :]], axis=0)
-
-    if py.shape[1] == 1:
-        dy = jnp.zeros_like(py)
-    else:
-        first_y = py[:, 0:1, :]
-        if py.shape[1] > 2:
-            mid_y = py[:, 1:-1, :] - py[:, 0:-2, :]
-            dy = jnp.concatenate([first_y, mid_y, -py[:, -2:-1, :]], axis=1)
-        else:
-            dy = jnp.concatenate([first_y, -py[:, -2:-1, :]], axis=1)
-
-    if pz.shape[2] == 1:
-        dz = jnp.zeros_like(pz)
-    else:
-        first_z = pz[:, :, 0:1]
-        if pz.shape[2] > 2:
-            mid_z = pz[:, :, 1:-1] - pz[:, :, 0:-2]
-            dz = jnp.concatenate([first_z, mid_z, -pz[:, :, -2:-1]], axis=2)
-        else:
-            dz = jnp.concatenate([first_z, -pz[:, :, -2:-1]], axis=2)
-    return dx + dy + dz
+GradMode = Literal["auto", "batched", "stream"]
 
 
 @dataclass
@@ -77,7 +40,7 @@ def grad_data_term(
     projector_unroll: int = 1,
     checkpoint_projector: bool = True,
     gather_dtype: str = "fp32",
-    grad_mode: Literal["auto", "batched", "stream"] = "auto",
+    grad_mode: GradMode = "auto",
     T_all: jnp.ndarray | None = None,
     vol_mask: Optional[jnp.ndarray] = None,
 ) -> Tuple[jnp.ndarray, float]:
@@ -93,10 +56,7 @@ def grad_data_term(
     nv = int(projections.shape[1])
     nu = int(projections.shape[2])
     if T_all is None:
-        T_all = jnp.stack(
-            [jnp.asarray(geometry.pose_for_view(i), dtype=jnp.float32) for i in range(n_views)],
-            axis=0,
-        )
+        T_all = stack_view_poses(geometry, n_views)
 
     det_grid = get_detector_grid_device(detector)
     mask_arr = None if vol_mask is None else jnp.asarray(vol_mask, dtype=jnp.float32)
@@ -226,7 +186,7 @@ def data_term_value(
     projector_unroll: int = 1,
     checkpoint_projector: bool = True,
     gather_dtype: str = "fp32",
-    grad_mode: Literal["auto", "batched", "stream"] = "auto",
+    grad_mode: GradMode = "auto",
     T_all: jnp.ndarray | None = None,
     vol_mask: Optional[jnp.ndarray] = None,
 ) -> jnp.ndarray:
@@ -235,10 +195,7 @@ def data_term_value(
     nv = int(projections.shape[1])
     nu = int(projections.shape[2])
     if T_all is None:
-        T_all = jnp.stack(
-            [jnp.asarray(geometry.pose_for_view(i), dtype=jnp.float32) for i in range(n_views)],
-            axis=0,
-        )
+        T_all = stack_view_poses(geometry, n_views)
 
     det_grid = get_detector_grid_device(detector)
 
@@ -328,17 +285,14 @@ def power_method_L(
     projector_unroll: int = 1,
     checkpoint_projector: bool = True,
     gather_dtype: str = "fp32",
-    grad_mode: Literal["auto", "batched", "stream"] = "auto",
+    grad_mode: GradMode = "auto",
     T_all: jnp.ndarray | None = None,
     vol_mask: Optional[jnp.ndarray] = None,
 ) -> float:
     """Estimate Lipschitz constant of ∇f(x) ≈ ||A||^2 via power method on AᵀA."""
     n_views, nv, nu = projections_shape
     if T_all is None:
-        T_all = jnp.stack(
-            [jnp.asarray(geometry.pose_for_view(i), dtype=jnp.float32) for i in range(n_views)],
-            axis=0,
-        )
+        T_all = stack_view_poses(geometry, n_views)
     zero_proj = jnp.zeros((n_views, nv, nu), dtype=jnp.float32)
     num_iters = max(1, int(iters))
 
@@ -385,7 +339,7 @@ def tv_proximal(x: jnp.ndarray, lam_over_L: float, iters: int = 20) -> jnp.ndarr
 
         def body(carry, _):
             u, u_bar, p1, p2, p3 = carry
-            gx, gy, gz = _grad3(u_bar)
+            gx, gy, gz = grad3(u_bar)
             p1_n = p1 + sigma * gx
             p2_n = p2 + sigma * gy
             p3_n = p3 + sigma * gz
@@ -393,7 +347,7 @@ def tv_proximal(x: jnp.ndarray, lam_over_L: float, iters: int = 20) -> jnp.ndarr
             p1_n = p1_n / norm
             p2_n = p2_n / norm
             p3_n = p3_n / norm
-            div_p = _div3(p1_n, p2_n, p3_n)
+            div_p = div3(p1_n, p2_n, p3_n)
             u_prev = u
             u_minus = u + tau * div_p
             u_n = (u_minus + tau * x) / (1.0 + tau)
@@ -428,7 +382,7 @@ def fista_tv(
     projector_unroll: int = 1,
     checkpoint_projector: bool = True,
     gather_dtype: str = "fp32",
-    grad_mode: Literal["auto", "batched", "stream"] = "auto",
+    grad_mode: GradMode = "auto",
     tv_prox_iters: int = 10,
     recon_rel_tol: float | None = None,
     recon_patience: int = 0,
@@ -455,10 +409,7 @@ def fista_tv(
     # Precompute poses once and thread them through the projector calls to avoid
     # repeatedly stacking in inner loops.
     n_views = int(projections.shape[0])
-    T_all = jnp.stack(
-        [jnp.asarray(geometry.pose_for_view(i), dtype=jnp.float32) for i in range(n_views)],
-        axis=0,
-    )
+    T_all = stack_view_poses(geometry, n_views)
 
     if L is None:
         # Use streamed gradient in power-method to avoid batched VJP memory spikes
@@ -545,7 +496,7 @@ def fista_tv(
             t_new = 0.5 * (1.0 + jnp.sqrt(1.0 + 4.0 * t_a * t_a))
             z_new = x_new + ((t_a - 1.0) / t_new) * (x_new - x_a)
             data_loss_val = data_value(x_new)
-            gx, gy, gz = _grad3(x_new)
+            gx, gy, gz = grad3(x_new)
             tv_norm = jnp.sum(jnp.sqrt(gx * gx + gy * gy + gz * gz + 1e-8))
             obj = data_loss_val + lambda_tv * tv_norm
             obj32 = obj.astype(jnp.float32)

--- a/src/tomojax/recon/multires.py
+++ b/src/tomojax/recon/multires.py
@@ -6,7 +6,7 @@ import math
 import jax.numpy as jnp
 import jax.image as jimage
 
-from ..core.geometry import Grid, Detector, Geometry
+from ..core.geometry.base import Grid, Detector, Geometry
 from .fista_tv import fista_tv, grad_data_term
 from ..utils.logging import progress_iter
 

--- a/src/tomojax/recon/spdhg_tv.py
+++ b/src/tomojax/recon/spdhg_tv.py
@@ -7,49 +7,10 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 
-from ..core.geometry import Geometry, Grid, Detector
+from ..core.geometry.base import Geometry, Grid, Detector
+from ..core.geometry.views import stack_view_poses
 from ..core.projector import _sum_backproject_views_T, forward_project_view_T, get_detector_grid_device
-
-
-# --------- finite differences (match your FISTA helpers) ----------
-def _grad3(u: jnp.ndarray):
-    dx = jnp.concatenate([jnp.diff(u, axis=0), jnp.zeros((1, u.shape[1], u.shape[2]), u.dtype)], axis=0)
-    dy = jnp.concatenate([jnp.diff(u, axis=1), jnp.zeros((u.shape[0], 1, u.shape[2]), u.dtype)], axis=1)
-    dz = jnp.concatenate([jnp.diff(u, axis=2), jnp.zeros((u.shape[0], u.shape[1], 1), u.dtype)], axis=2)
-    return dx, dy, dz
-
-def _div3(px: jnp.ndarray, py: jnp.ndarray, pz: jnp.ndarray):
-    """Discrete divergence matching the TV updates: ``_div3 = -_grad3*``."""
-    if px.shape[0] == 1:
-        dx = jnp.zeros_like(px)
-    else:
-        first_x = px[0:1, :, :]
-        if px.shape[0] > 2:
-            mid_x = px[1:-1, :, :] - px[0:-2, :, :]
-            dx = jnp.concatenate([first_x, mid_x, -px[-2:-1, :, :]], axis=0)
-        else:
-            dx = jnp.concatenate([first_x, -px[-2:-1, :, :]], axis=0)
-
-    if py.shape[1] == 1:
-        dy = jnp.zeros_like(py)
-    else:
-        first_y = py[:, 0:1, :]
-        if py.shape[1] > 2:
-            mid_y = py[:, 1:-1, :] - py[:, 0:-2, :]
-            dy = jnp.concatenate([first_y, mid_y, -py[:, -2:-1, :]], axis=1)
-        else:
-            dy = jnp.concatenate([first_y, -py[:, -2:-1, :]], axis=1)
-
-    if pz.shape[2] == 1:
-        dz = jnp.zeros_like(pz)
-    else:
-        first_z = pz[:, :, 0:1]
-        if pz.shape[2] > 2:
-            mid_z = pz[:, :, 1:-1] - pz[:, :, 0:-2]
-            dz = jnp.concatenate([first_z, mid_z, -pz[:, :, -2:-1]], axis=2)
-        else:
-            dz = jnp.concatenate([first_z, -pz[:, :, -2:-1]], axis=2)
-    return dx + dy + dz
+from ._tv_ops import div3, grad3
 
 
 # --------- config ----------
@@ -203,10 +164,7 @@ def spdhg_tv(
     W = jnp.ones_like(y_meas) if weights is None else jnp.asarray(weights, dtype=jnp.float32)
 
     # precompute per-view poses once (like your FISTA)
-    T_all = jnp.stack(
-        [jnp.asarray(geometry.pose_for_view(i), dtype=jnp.float32) for i in range(n_views)],
-        axis=0,
-    )
+    T_all = stack_view_poses(geometry, n_views)
     det_grid = get_detector_grid_device(detector)
 
     # batched projector over a chunk of views
@@ -318,14 +276,14 @@ def spdhg_tv(
         )
 
         # TV DUAL UPDATE (global)
-        gx, gy, gz = _grad3(x_bar)
+        gx, gy, gz = grad3(x_bar)
         p1_u = p1 + sigma_tv * gx
         p2_u = p2 + sigma_tv * gy
         p3_u = p3 + sigma_tv * gz
         norm = jnp.maximum(1.0, jnp.sqrt(p1_u*p1_u + p2_u*p2_u + p3_u*p3_u) / jnp.maximum(lam, 1e-12))
         p1_new = p1_u / norm; p2_new = p2_u / norm; p3_new = p3_u / norm
         # TV contributes with -div(p) in the primal gradient; track the increment
-        delta_div = _div3(p1_new - p1, p2_new - p2, p3_new - p3)
+        delta_div = div3(p1_new - p1, p2_new - p2, p3_new - p3)
 
         # update accumulator s
         # Update accumulator: A^T y + (-div p)
@@ -347,7 +305,7 @@ def spdhg_tv(
         def _log_step():
             resid = (pred - y_chunk) * jnp.sqrt(w_chunk) * row_mask
             data_est = 0.5 * jnp.vdot(resid, resid).real * (float(n_views) / jnp.maximum(valid.astype(jnp.float32), 1.0))
-            gx2, gy2, gz2 = _grad3(x_new)
+            gx2, gy2, gz2 = grad3(x_new)
             tv = jnp.sum(jnp.sqrt(gx2*gx2 + gy2*gy2 + gz2*gz2 + 1e-8))
             obj = (data_est + lam * tv).astype(jnp.float32)
             return losses.at[t].set(obj)
@@ -365,11 +323,12 @@ def spdhg_tv(
 
     # optional callback with the last logged loss
     if callback is not None:
-        last_logged = int(np.where(np.array((np.arange(config.iters)+1) % config.log_every == 0))[0][-1]) if config.log_every>0 and config.iters>=config.log_every else config.iters-1
-        try:
-            callback(last_logged, float(losses_f[last_logged]))
-        except Exception:
-            pass
+        last_logged = (
+            int(np.where(np.array((np.arange(config.iters) + 1) % config.log_every == 0))[0][-1])
+            if config.log_every > 0 and config.iters >= config.log_every
+            else config.iters - 1
+        )
+        callback(last_logged, float(losses_f[last_logged]))
 
     info = {
         "loss": [float(v) for v in list(losses_f)],

--- a/src/tomojax/utils/axes.py
+++ b/src/tomojax/utils/axes.py
@@ -2,28 +2,26 @@
 
 from __future__ import annotations
 
-from typing import Optional, Sequence, Tuple
+from typing import Sequence
 
 import numpy as np
+
+from ..core.geometry.base import Grid, GridDict
 
 try:  # pragma: no cover - JAX might be absent in build docs
     import jax  # type: ignore
     import jax.numpy as jnp  # type: ignore
 
-    if hasattr(jax, "Array"):
-        _JAX_ARRAY_TYPES = (jax.Array,)  # type: ignore[attr-defined]
-    else:  # Fallback for older JAX
-        from jax.interpreters.xla import DeviceArray  # type: ignore
-
-        _JAX_ARRAY_TYPES = (DeviceArray,)  # type: ignore[assignment]
+    _JAX_ARRAY_TYPES = (jax.Array,)  # type: ignore[attr-defined]
 except Exception:  # pragma: no cover - non-JAX contexts
     jnp = None  # type: ignore[assignment]
-    _JAX_ARRAY_TYPES: Tuple[type, ...] = ()
+    _JAX_ARRAY_TYPES: tuple[type, ...] = ()
 
 
 INTERNAL_VOLUME_AXES = "xyz"
 DISK_VOLUME_AXES = "zyx"
 VOLUME_AXES_ATTR = "volume_axes_order"
+GridLike = Grid | GridDict
 
 
 def _norm_axes(axes: str) -> str:
@@ -35,7 +33,7 @@ def _norm_axes(axes: str) -> str:
     return axes
 
 
-def axes_to_perm(src: str, dst: str) -> Tuple[int, int, int]:
+def axes_to_perm(src: str, dst: str) -> tuple[int, int, int]:
     """Return permutation bringing `src` axis order into `dst` order."""
 
     s = _norm_axes(src)
@@ -64,7 +62,7 @@ def transpose_volume(volume: np.ndarray, src: str, dst: str):
     return np.transpose(arr, axes=perm)
 
 
-def _grid_dims(grid: Optional[object]) -> Optional[Tuple[int, int, int]]:
+def _grid_dims(grid: GridLike | None) -> tuple[int, int, int] | None:
     if grid is None:
         return None
     if hasattr(grid, "nx") and hasattr(grid, "ny") and hasattr(grid, "nz"):
@@ -80,7 +78,7 @@ def _grid_dims(grid: Optional[object]) -> Optional[Tuple[int, int, int]]:
     return None
 
 
-def is_shape_xyz(vol_shape: Sequence[int], grid: Optional[object]) -> bool:
+def is_shape_xyz(vol_shape: Sequence[int], grid: GridLike | None) -> bool:
     dims = _grid_dims(grid)
     if dims is None:
         return False
@@ -89,7 +87,7 @@ def is_shape_xyz(vol_shape: Sequence[int], grid: Optional[object]) -> bool:
     return tuple(int(s) for s in vol_shape) == dims
 
 
-def is_shape_zyx(vol_shape: Sequence[int], grid: Optional[object]) -> bool:
+def is_shape_zyx(vol_shape: Sequence[int], grid: GridLike | None) -> bool:
     dims = _grid_dims(grid)
     if dims is None:
         return False
@@ -98,7 +96,7 @@ def is_shape_zyx(vol_shape: Sequence[int], grid: Optional[object]) -> bool:
     return tuple(int(s) for s in vol_shape) == (dims[2], dims[1], dims[0])
 
 
-def infer_disk_axes(vol_shape: Sequence[int], grid: Optional[object]) -> Optional[str]:
+def infer_disk_axes(vol_shape: Sequence[int], grid: GridLike | None) -> str | None:
     """Infer on-disk axis order using grid heuristics.
 
     Returns "xyz", "zyx", or None if ambiguous.

--- a/src/tomojax/utils/logging.py
+++ b/src/tomojax/utils/logging.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import math
 import os
-from typing import Iterable, Iterator, Optional
+from typing import Iterable, Iterator
 
 
 def setup_logging(level: str = "INFO") -> None:
@@ -15,10 +15,7 @@ def setup_logging(level: str = "INFO") -> None:
             "jax._src.xla_bridge",
             "jax._src.xla_client",
         ):
-            try:
-                logging.getLogger(name).setLevel(logging.WARNING)
-            except Exception:
-                pass
+            logging.getLogger(name).setLevel(logging.WARNING)
 
 
 def log_jax_env() -> None:
@@ -35,7 +32,12 @@ def _progress_enabled() -> bool:
     return v in ("1", "true", "yes", "on")
 
 
-def progress_iter(iterable: Iterable, *, total: Optional[int] = None, desc: str = "") -> Iterator:
+def progress_iter[T](
+    iterable: Iterable[T],
+    *,
+    total: int | None = None,
+    desc: str = "",
+) -> Iterator[T]:
     """Yield elements from iterable, showing a progress bar if enabled.
 
     Enable by setting environment variable `TOMOJAX_PROGRESS=1` or calling CLIs with `--progress`.

--- a/src/tomojax/utils/memory.py
+++ b/src/tomojax/utils/memory.py
@@ -103,8 +103,6 @@ def estimate_views_per_batch(
     if budget <= static_bytes:
         return 1
 
-    per_batch = lambda b: static_bytes + int(algo_factor * fudge * per_view * b)
-
     # Largest b such that per_batch(b) <= budget
     b_est = (budget - static_bytes) / float(algo_factor * fudge * per_view)
     b = int(max(1, math.floor(b_est)))

--- a/src/tomojax/utils/phasecorr.py
+++ b/src/tomojax/utils/phasecorr.py
@@ -17,8 +17,7 @@ def _wrap_shift(idx: jnp.ndarray | int, n: int) -> jnp.ndarray:
 def phase_corr_shift(ref: jnp.ndarray, tgt: jnp.ndarray) -> tuple[jnp.ndarray, jnp.ndarray]:
     """Estimate (du, dv) translation from ref -> tgt via phase correlation.
 
-    Inputs are 2D arrays (nv, nu). Returns shifts in pixel units (u, v).
-    Uses integer-precision peak (robust and cheap); refine later if needed.
+    Inputs are 2D arrays (nv, nu). Returns integer-pixel shifts in (u, v).
     """
     ref = ref.astype(jnp.float32)
     tgt = tgt.astype(jnp.float32)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -8,9 +8,7 @@ from tomojax.core.geometry import (
     ParallelGeometry,
     LaminographyGeometry,
 )
-from tomojax.core.geometry.lamino import laminography_tilt_matrix
 from tomojax.core.geometry.transforms import rotz, rot_axis_angle, exp_se3, invert, compose
-import numpy as np
 
 
 if sys.version_info < (3, 8):

--- a/tests/test_misalign_schedules.py
+++ b/tests/test_misalign_schedules.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import json
 import numpy as np
 import jax.numpy as jnp
 import pytest

--- a/tests/test_projector_precision.py
+++ b/tests/test_projector_precision.py
@@ -1,4 +1,3 @@
-import numpy as np
 import jax.numpy as jnp
 from tomojax.core.geometry import Grid, Detector, ParallelGeometry
 from tomojax.core.projector import forward_project_view

--- a/tests/test_spdhg.py
+++ b/tests/test_spdhg.py
@@ -68,3 +68,14 @@ def test_spdhg_keeps_configured_data_dual_step_under_block_sampling():
     assert info["selection_prob"] == pytest.approx(0.25)
     assert info["sigma_data_base"] == pytest.approx(0.2)
     assert info["sigma_data"] == pytest.approx(0.2)
+
+
+def test_spdhg_callback_exceptions_propagate():
+    grid, det, geom, vol, projs = make_simple_case(8, 8, 8, 4)
+    cfg = SPDHGConfig(iters=1, lambda_tv=1e-3, views_per_batch=2, log_every=1, seed=0)
+
+    def fail_callback(step: int, loss: float) -> None:
+        raise RuntimeError("callback failure")
+
+    with pytest.raises(RuntimeError, match="callback failure"):
+        spdhg_tv(geom, grid, det, projs, config=cfg, callback=fail_callback)


### PR DESCRIPTION
## Summary
This PR is a broad code-quality pass over core geometry, reconstruction, alignment, CLI, IO, and utility internals. It reduces duplication, tightens internal typing, removes dead and legacy paths, and simplifies a few defensive branches that were hiding errors.

## Why
The affected modules had repeated helper logic, broad internal types, a few confirmed dead paths, and fallback code that added maintenance overhead without providing clear value. This change aims to make the core code paths easier to read, reason about, and maintain without intentionally changing user-facing behavior.

## What changed

### 1. Consolidated duplicated logic
- Added `src/tomojax/core/geometry/views.py` for shared pose stacking via `stack_view_poses(...)`.
- Added `src/tomojax/recon/_tv_ops.py` for shared 3D TV gradient/divergence helpers.
- Shared parallel detector-ray construction from `src/tomojax/core/geometry/base.py` so `parallel.py` and `lamino.py` use the same implementation.

### 2. Tightened internal typing
- Shared geometry aliases and dict contracts in `src/tomojax/core/geometry/base.py`.
- Replaced several loose `Any` / broad `dict` / `object` annotations in alignment observer payloads, geometry loading metadata, simulation outputs, dataset/report payloads, and utility helpers with stronger internal types.
- Consolidated repeated literal/callback signatures where the same shapes were already used across modules.

### 3. Removed dead and legacy paths
- Removed confirmed unused imports, locals, and one unused helper in `cli/misalign.py`.
- Dropped older-JAX `DeviceArray` fallback branches now that `pyproject.toml` pins `jax>=0.5.3,<0.6`.
- Kept compatibility-sensitive HDF5 and CLI paths when they still appeared intentional and test-backed.

### 4. Simplified error handling
- Let SPDHG callback exceptions propagate instead of silently swallowing them.
- Replaced redundant `block_until_ready` try/fallback wrappers with direct `jax.block_until_ready(...)` calls.
- Removed a non-functional `try/except` around logger level setup.

### 5. Reduced import coupling
- No actual circular dependencies were found in `src/tomojax`.
- Internal recon/alignment modules that only need base geometry types now import them from `tomojax.core.geometry.base` instead of the broader package re-export, which narrows coupling and lowers future cycle risk.

### 6. Removed stale comments / slop
- Removed stale removed-feature comments and future-work phrasing.
- Tightened a few remaining comments/docstrings so they describe current behavior more directly.

## Audit approach
Because this is a Python codebase, I used Python-appropriate tooling rather than JS-centric tools:
- Dead code: `ruff` and `vulture`
- Circular-dependency audit: Python AST import-graph analysis
- Validation: repo `ruff` + full test suite

## Validation
- `uv run ruff check src tests`
- `JAX_PLATFORM_NAME=cpu uv run pytest -q tests`
  - `142 passed`

## Reviewer notes
- This is intended as an internal cleanup/refactor PR; no user-facing behavior changes are intended.
- The only explicit behavior-tightening is that callback failures in SPDHG now surface instead of being hidden.
- The diff is broad, but it clusters into the six buckets above and was validated as a single pass.
