### PR TITLE
Add auto views-per-batch selection for reconstruction CLI

### DIFF
--- a/src/tomojax/align/pipeline.py
+++ b/src/tomojax/align/pipeline.py
@@ -12,6 +12,13 @@ import jax.numpy as jnp
 from ..core.geometry.base import Geometry, Grid, Detector
 from ..core.geometry.views import stack_view_poses
 from ..core.projector import forward_project_view_T, get_detector_grid_device
+from ..core.validation import (
+    validate_grid,
+    validate_optional_same_shape,
+    validate_pose_stack,
+    validate_projection_stack,
+    validate_volume,
+)
 from ..recon.fista_tv import FistaConfig, fista_tv
 from ..utils.logging import progress_iter, format_duration
 from .parametrizations import se3_from_5d
@@ -277,7 +284,22 @@ def align(
     """
     if cfg is None:
         cfg = AlignConfig()
-    n_views = int(projections.shape[0])
+    validate_grid(grid, "align grid")
+    n_views, _, _ = validate_projection_stack(
+        projections,
+        detector,
+        geometry=geometry,
+        context="align projections",
+    )
+    if init_x is not None:
+        validate_volume(init_x, grid, context="align init_x", name="init_x")
+    validate_optional_same_shape(
+        init_params5,
+        (n_views, 5),
+        context="align init_params5",
+        name="init_params5",
+        fix="pass one 5-parameter alignment row per projection view.",
+    )
     # Initialize volume and params
     x = (
         jnp.asarray(init_x, dtype=jnp.float32)
@@ -295,8 +317,8 @@ def align(
     observer_action: ObserverAction = "continue"
 
     # Precompute nominal poses once
-    n_views = int(projections.shape[0])
     T_nom_all = stack_view_poses(geometry, n_views)
+    validate_pose_stack(T_nom_all, n_views, context="align geometry")
 
     # Precompute detector grid once (device arrays) to avoid repeated transfers/logging
     det_grid = get_detector_grid_device(detector)
@@ -1144,14 +1166,31 @@ def align_multires(
     if cfg is None:
         cfg = AlignConfig()
 
+    validate_grid(grid, "align_multires grid")
+    validate_projection_stack(
+        projections,
+        detector,
+        geometry=geometry,
+        context="align_multires projections",
+    )
+
     levels: list[MultiresLevel] = []
     for f in factors:
+        g = scale_grid(grid, int(f))
+        d = scale_detector(detector, int(f))
+        y = bin_projections(projections, int(f))
+        validate_projection_stack(
+            y,
+            d,
+            geometry=geometry,
+            context=f"align_multires level factor {int(f)} projections",
+        )
         levels.append(
             {
                 "factor": int(f),
-                "grid": scale_grid(grid, int(f)),
-                "detector": scale_detector(detector, int(f)),
-                "projections": bin_projections(projections, int(f)),
+                "grid": g,
+                "detector": d,
+                "projections": y,
             }
         )
 

--- a/src/tomojax/cli/recon.py
+++ b/src/tomojax/cli/recon.py
@@ -9,11 +9,13 @@ import os
 
 from ..data.geometry_meta import build_geometry_from_meta
 from ..data.io_hdf5 import NXTomoMetadata, load_nxtomo, save_nxtomo
+from ..core.geometry import Detector, Grid
 from ..recon.fbp import fbp
 from ..recon.fista_tv import FistaConfig, fista_tv
 from ..recon.quicklook import save_quicklook_png
 from ..recon.spdhg_tv import spdhg_tv, SPDHGConfig
 from ..utils.logging import setup_logging, log_jax_env
+from ..utils.memory import estimate_views_per_batch_info
 from ..utils.axes import DISK_VOLUME_AXES
 from ._runtime import transfer_guard_context
 
@@ -23,6 +25,58 @@ from ..utils.fov import (
     grid_from_detector_fov,
 )
 from ..utils.fov import cylindrical_mask_xy
+
+
+def _parse_views_per_batch(value: str) -> int | str:
+    """Parse ``--views-per-batch`` as a positive/zero integer or ``auto``."""
+    text = str(value).strip()
+    if text.lower() == "auto":
+        return "auto"
+    try:
+        return int(text)
+    except ValueError:
+        raise argparse.ArgumentTypeError("--views-per-batch must be 'auto' or an integer")
+
+
+def _default_views_per_batch(algo: str) -> int:
+    return 16 if str(algo).lower() == "spdhg" else 1
+
+
+def _resolve_views_per_batch(
+    requested: int | str | None,
+    *,
+    algo: str,
+    n_views: int,
+    grid: Grid,
+    detector: Detector,
+    gather_dtype: str,
+    checkpoint_projector: bool,
+) -> tuple[int, str]:
+    """Resolve CLI batching after ROI/grid choices are known."""
+    if requested is None:
+        return _default_views_per_batch(algo), "default"
+
+    if isinstance(requested, str) and requested.lower() == "auto":
+        estimate = estimate_views_per_batch_info(
+            n_views=int(n_views),
+            grid_nxyz=(int(grid.nx), int(grid.ny), int(grid.nz)),
+            det_nuv=(int(detector.nv), int(detector.nu)),
+            gather_dtype=str(gather_dtype),
+            projection_dtype="fp32",
+            volume_dtype="fp32",
+            checkpoint_projector=bool(checkpoint_projector),
+            algo=str(algo),
+            fallback_batch=1,
+        )
+        if estimate.fallback_used:
+            logging.warning(
+                "Could not determine available memory for --views-per-batch auto; "
+                "using views_per_batch=%d",
+                estimate.views_per_batch,
+            )
+        return int(estimate.views_per_batch), "auto"
+
+    return max(1, int(requested)), "explicit"
 
 
 def main() -> None:
@@ -57,9 +111,12 @@ def main() -> None:
     # SPDHG-specific knobs
     p.add_argument(
         "--views-per-batch",
-        type=int,
-        default=16,
-        help="SPDHG: views per stochastic block",
+        type=_parse_views_per_batch,
+        default=None,
+        help=(
+            "Views per projection batch, or 'auto' to estimate from available memory "
+            "(default: 1 for FBP/FISTA, 16 for SPDHG)"
+        ),
     )
     p.add_argument("--theta", type=float, default=1.0, help="SPDHG: extrapolation for xbar")
     p.add_argument("--spdhg-seed", type=int, default=0, help="SPDHG: RNG seed for block order")
@@ -188,9 +245,6 @@ def main() -> None:
     )
     proj = jnp.asarray(meta.projections, dtype=jnp.float32)
 
-    # Keep FBP/FISTA on their streamed defaults; this flag is SPDHG-specific.
-    spdhg_vpb = int(args.views_per_batch) if int(args.views_per_batch) > 0 else 1
-
     from ..utils.memory import default_gather_dtype as _default_gather_dtype
 
     _gather = str(args.gather_dtype)
@@ -252,6 +306,22 @@ def main() -> None:
     except Exception:
         vol_mask = None
 
+    resolved_vpb, vpb_mode = _resolve_views_per_batch(
+        args.views_per_batch,
+        algo=str(args.algo),
+        n_views=int(proj.shape[0]),
+        grid=recon_grid,
+        detector=detector,
+        gather_dtype=_gather,
+        checkpoint_projector=bool(args.checkpoint_projector),
+    )
+    logging.info(
+        "Reconstruction views_per_batch=%d (mode=%s, algo=%s)",
+        resolved_vpb,
+        vpb_mode,
+        args.algo,
+    )
+
     if args.algo == "fbp":
         with transfer_guard_context(args.transfer_guard):
             vol = fbp(
@@ -260,7 +330,7 @@ def main() -> None:
                 detector,
                 proj,
                 filter_name=args.filter,
-                views_per_batch=1,
+                views_per_batch=resolved_vpb,
                 projector_unroll=1,
                 checkpoint_projector=bool(args.checkpoint_projector),
                 gather_dtype=_gather,
@@ -273,7 +343,7 @@ def main() -> None:
             iters=int(args.iters),
             lambda_tv=float(args.lambda_tv),
             L=(float(args.L) if args.L is not None else None),
-            views_per_batch=1,
+            views_per_batch=resolved_vpb,
             projector_unroll=1,
             checkpoint_projector=bool(args.checkpoint_projector),
             gather_dtype=_gather,
@@ -294,7 +364,7 @@ def main() -> None:
             iters=int(args.iters),
             lambda_tv=float(args.lambda_tv),
             theta=float(args.theta),
-            views_per_batch=int(spdhg_vpb),
+            views_per_batch=int(resolved_vpb),
             seed=int(args.spdhg_seed),
             tau=(float(args.spdhg_tau) if args.spdhg_tau is not None else None),
             sigma_data=(
@@ -312,13 +382,14 @@ def main() -> None:
         init_x = None
         if str(args.warm_start).lower() == "fbp":
             # Compute a quick FBP and use as initialization
+            warm_start_vpb = 1 if vpb_mode == "default" else int(resolved_vpb)
             init_x = fbp(
                 geom,
                 recon_grid,
                 detector,
                 proj,
                 filter_name=str(args.filter),
-                views_per_batch=1,
+                views_per_batch=warm_start_vpb,
                 projector_unroll=1,
                 checkpoint_projector=bool(args.checkpoint_projector),
                 gather_dtype=_gather,

--- a/src/tomojax/core/projector.py
+++ b/src/tomojax/core/projector.py
@@ -9,6 +9,16 @@ import jax.numpy as jnp
 import numpy as np
 
 from .geometry.base import Grid, Detector, Geometry
+from .validation import (
+    validate_detector,
+    validate_detector_grid,
+    validate_detector_image,
+    validate_grid,
+    validate_pose_matrix,
+    validate_pose_stack,
+    validate_projection_stack,
+    validate_volume,
+)
 
 # Frame conventions:
 # - geometry.pose_for_view(i) must return a 4x4 transform T_world_from_obj that maps
@@ -286,11 +296,10 @@ def forward_project_view_T(
     in the object frame. This avoids a matmul per step and keeps gradients clean.
     """
     vol = volume
-    if vol.ndim != 3:
-        raise ValueError("volume must be 3D array")
-    nx, ny, nz = int(grid.nx), int(grid.ny), int(grid.nz)
-    if vol.shape != (nx, ny, nz):
-        raise ValueError(f"Volume must be (nx,ny,nz)={nx, ny, nz}, got {vol.shape}")
+    nx, ny, nz = validate_volume(vol, grid, context="forward_project_view_T", name="volume")
+    validate_detector(detector, "forward_project_view_T")
+    validate_detector_grid(det_grid, detector, context="forward_project_view_T")
+    validate_pose_matrix(T, context="forward_project_view_T")
     recon_flat = _prepare_volume_for_gather(vol, gather_dtype)
     ix0, iy0, iz0, dix, diy, diz, n_steps_ray, step_size32, n_steps, n_rays = (
         _projector_traversal_state(
@@ -336,13 +345,10 @@ def _backproject_view_accum_T(
     det_grid: tuple[jnp.ndarray, jnp.ndarray] | None = None,
 ) -> jnp.ndarray:
     img = jnp.asarray(image, dtype=jnp.float32)
-    if img.ndim != 2:
-        raise ValueError("image must be 2D array")
-    if img.shape != (int(detector.nv), int(detector.nu)):
-        raise ValueError(
-            f"Image must be (nv,nu)={(int(detector.nv), int(detector.nu))}, got {img.shape}"
-        )
-    nx, ny, nz = int(grid.nx), int(grid.ny), int(grid.nz)
+    nx, ny, nz = validate_grid(grid, "backproject_view_T")
+    validate_detector_image(img, detector, context="backproject_view_T", name="image")
+    validate_detector_grid(det_grid, detector, context="backproject_view_T")
+    validate_pose_matrix(T, context="backproject_view_T")
     ix0, iy0, iz0, dix, diy, diz, n_steps_ray, step_size32, n_steps, _ = _projector_traversal_state(
         T,
         grid,
@@ -418,6 +424,14 @@ def sum_backproject_views_T(
     det_grid: tuple[jnp.ndarray, jnp.ndarray] | None = None,
 ) -> jnp.ndarray:
     """Sum explicit mixed-precision adjoints over a fixed chunk without stacking volumes."""
+    n_views, _, _ = validate_projection_stack(
+        images,
+        detector,
+        context="sum_backproject_views_T",
+    )
+    validate_pose_stack(T_all, n_views, context="sum_backproject_views_T")
+    validate_detector_grid(det_grid, detector, context="sum_backproject_views_T")
+    validate_grid(grid, "sum_backproject_views_T")
     img = jnp.asarray(images, dtype=jnp.float32)
 
     def body(accum, inputs):

--- a/src/tomojax/core/validation.py
+++ b/src/tomojax/core/validation.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+import math
+from typing import Any, Iterable
+
+import numpy as np
+
+from .geometry.base import Detector, Geometry, Grid
+
+
+def _shape_of(value: Any) -> tuple[int, ...]:
+    shape = getattr(value, "shape", None)
+    if shape is None:
+        try:
+            shape = np.shape(value)
+        except Exception:
+            shape = ()
+    return tuple(int(s) for s in shape)
+
+
+def _shape_text(shape: Iterable[object]) -> str:
+    items: list[object] = []
+    for s in shape:
+        try:
+            items.append(int(s))
+        except Exception:
+            items.append(s)
+    return str(tuple(items))
+
+
+def _raise_shape_error(
+    context: str,
+    name: str,
+    *,
+    expected: str,
+    actual: Iterable[int],
+    fix: str,
+    kind: str = "incompatible",
+) -> None:
+    raise ValueError(
+        f"{context}: {name} has {kind} shape; expected {expected}, "
+        f"actual {_shape_text(actual)}. Likely fix: {fix}"
+    )
+
+
+def _raise_value_error(
+    context: str,
+    name: str,
+    *,
+    expected: str,
+    actual: object,
+    fix: str,
+) -> None:
+    raise ValueError(
+        f"{context}: {name} has invalid values; expected {expected}, "
+        f"actual {actual}. Likely fix: {fix}"
+    )
+
+
+def _is_positive_int(value: object) -> bool:
+    try:
+        ivalue = int(value)  # type: ignore[arg-type]
+    except Exception:
+        return False
+    try:
+        return ivalue > 0 and float(value) == float(ivalue)  # type: ignore[arg-type]
+    except Exception:
+        return False
+
+
+def _is_positive_finite(value: object) -> bool:
+    try:
+        fvalue = float(value)  # type: ignore[arg-type]
+    except Exception:
+        return False
+    return math.isfinite(fvalue) and fvalue > 0.0
+
+
+def _geometry_view_count(geometry: Geometry | None) -> int | None:
+    if geometry is None:
+        return None
+    thetas = getattr(geometry, "thetas_deg", None)
+    if thetas is None:
+        return None
+    try:
+        return int(len(thetas))
+    except Exception:
+        return None
+
+
+def validate_grid(grid: Grid, context: str) -> tuple[int, int, int]:
+    """Validate reconstruction grid metadata and return ``(nx, ny, nz)``."""
+    dims = (getattr(grid, "nx", None), getattr(grid, "ny", None), getattr(grid, "nz", None))
+    if not all(_is_positive_int(v) for v in dims):
+        _raise_shape_error(
+            context,
+            "reconstruction grid",
+            expected="positive integer (nx, ny, nz)",
+            actual=dims,
+            fix="pass --grid NX NY NZ with all values > 0 or fix grid metadata.",
+            kind="invalid",
+        )
+
+    spacing = (getattr(grid, "vx", None), getattr(grid, "vy", None), getattr(grid, "vz", None))
+    if not all(_is_positive_finite(v) for v in spacing):
+        _raise_value_error(
+            context,
+            "voxel spacing",
+            expected="positive finite (vx, vy, vz)",
+            actual=spacing,
+            fix="fix grid voxel-size metadata so vx, vy, and vz are finite and > 0.",
+        )
+    return int(grid.nx), int(grid.ny), int(grid.nz)
+
+
+def validate_detector(detector: Detector, context: str) -> tuple[int, int]:
+    """Validate detector metadata and return detector image shape ``(nv, nu)``."""
+    shape = (getattr(detector, "nv", None), getattr(detector, "nu", None))
+    if not all(_is_positive_int(v) for v in shape):
+        _raise_shape_error(
+            context,
+            "detector",
+            expected="positive integer (nv, nu)",
+            actual=shape,
+            fix="fix detector metadata so nv and nu are both positive integers.",
+            kind="invalid",
+        )
+
+    spacing = (getattr(detector, "dv", None), getattr(detector, "du", None))
+    if not all(_is_positive_finite(v) for v in spacing):
+        _raise_value_error(
+            context,
+            "detector spacing",
+            expected="positive finite (dv, du)",
+            actual=spacing,
+            fix="fix detector metadata so dv and du are finite and > 0.",
+        )
+    return int(detector.nv), int(detector.nu)
+
+
+def validate_projection_shape(
+    projections_shape: Iterable[int],
+    detector: Detector,
+    *,
+    geometry: Geometry | None = None,
+    context: str,
+) -> tuple[int, int, int]:
+    """Validate a projection-stack shape tuple without requiring an array."""
+    nv, nu = validate_detector(detector, context)
+    shape = tuple(int(s) for s in projections_shape)
+    if len(shape) != 3:
+        _raise_shape_error(
+            context,
+            "projections",
+            expected=f"(n_views, nv, nu)=(*, {nv}, {nu}) from detector",
+            actual=shape,
+            fix="pass projections with shape (number of angles, detector.nv, detector.nu).",
+        )
+
+    n_views = int(shape[0])
+    if n_views <= 0:
+        _raise_shape_error(
+            context,
+            "projections",
+            expected=f"non-empty (n_views, nv, nu)=(*, {nv}, {nu}) from detector",
+            actual=shape,
+            fix="provide at least one projection view and one matching angle.",
+            kind="invalid",
+        )
+
+    geometry_n_views = _geometry_view_count(geometry)
+    expected_n_views = geometry_n_views if geometry_n_views is not None else n_views
+    expected = f"(n_views, nv, nu)=({expected_n_views}, {nv}, {nu})"
+    source = "geometry/detector" if geometry_n_views is not None else "detector"
+    expected = f"{expected} from {source}"
+    if geometry_n_views is not None and n_views != geometry_n_views:
+        _raise_shape_error(
+            context,
+            "projections",
+            expected=expected,
+            actual=shape,
+            fix="use projections generated with the same angle list and detector metadata.",
+        )
+    if shape[1:] != (nv, nu):
+        _raise_shape_error(
+            context,
+            "projections",
+            expected=expected,
+            actual=shape,
+            fix=(
+                "use detector metadata matching the projection detector axes, or reshape/reload "
+                "projections as (n_views, detector.nv, detector.nu)."
+            ),
+        )
+    return n_views, nv, nu
+
+
+def validate_projection_stack(
+    projections: Any,
+    detector: Detector,
+    *,
+    geometry: Geometry | None = None,
+    context: str,
+) -> tuple[int, int, int]:
+    """Validate projections with expected shape ``(n_views, detector.nv, detector.nu)``."""
+    return validate_projection_shape(
+        _shape_of(projections),
+        detector,
+        geometry=geometry,
+        context=context,
+    )
+
+
+def validate_volume(
+    volume: Any,
+    grid: Grid,
+    *,
+    context: str,
+    name: str = "volume",
+) -> tuple[int, int, int]:
+    expected_shape = validate_grid(grid, context)
+    actual_shape = _shape_of(volume)
+    if actual_shape != expected_shape:
+        _raise_shape_error(
+            context,
+            name,
+            expected=f"(nx, ny, nz)={expected_shape} from grid",
+            actual=actual_shape,
+            fix="use a volume/init_x/support array generated for the same reconstruction grid.",
+        )
+    return expected_shape
+
+
+def validate_detector_image(
+    image: Any,
+    detector: Detector,
+    *,
+    context: str,
+    name: str = "image",
+) -> tuple[int, int]:
+    expected_shape = validate_detector(detector, context)
+    actual_shape = _shape_of(image)
+    if actual_shape != expected_shape:
+        _raise_shape_error(
+            context,
+            name,
+            expected=f"(nv, nu)={expected_shape} from detector",
+            actual=actual_shape,
+            fix="use an image generated with the same detector metadata.",
+        )
+    return expected_shape
+
+
+def validate_pose_matrix(T: Any, *, context: str, name: str = "pose") -> tuple[int, int]:
+    actual_shape = _shape_of(T)
+    expected_shape = (4, 4)
+    if actual_shape != expected_shape:
+        _raise_shape_error(
+            context,
+            name,
+            expected="(4, 4) homogeneous world_from_object transform",
+            actual=actual_shape,
+            fix="return or pass one 4x4 pose matrix for each view.",
+        )
+    return expected_shape
+
+
+def validate_pose_stack(
+    T_all: Any,
+    n_views: int,
+    *,
+    context: str,
+    name: str = "poses",
+) -> tuple[int, int, int]:
+    expected_shape = (int(n_views), 4, 4)
+    actual_shape = _shape_of(T_all)
+    if actual_shape != expected_shape:
+        _raise_shape_error(
+            context,
+            name,
+            expected=f"(n_views, 4, 4)={expected_shape}",
+            actual=actual_shape,
+            fix="stack exactly one 4x4 pose matrix per projection view.",
+        )
+    return expected_shape
+
+
+def validate_optional_same_shape(
+    value: Any | None,
+    expected_shape: Iterable[int],
+    *,
+    context: str,
+    name: str,
+    fix: str,
+) -> tuple[int, ...] | None:
+    if value is None:
+        return None
+    expected = tuple(int(s) for s in expected_shape)
+    actual = _shape_of(value)
+    if actual != expected:
+        _raise_shape_error(
+            context,
+            name,
+            expected=_shape_text(expected),
+            actual=actual,
+            fix=fix,
+        )
+    return expected
+
+
+def validate_optional_broadcastable_shape(
+    value: Any | None,
+    expected_shape: Iterable[int],
+    *,
+    context: str,
+    name: str,
+    fix: str,
+) -> tuple[int, ...] | None:
+    if value is None:
+        return None
+    expected = tuple(int(s) for s in expected_shape)
+    actual = _shape_of(value)
+    try:
+        broadcast = np.broadcast_shapes(actual, expected)
+    except ValueError:
+        broadcast = None
+    if broadcast != expected:
+        _raise_shape_error(
+            context,
+            name,
+            expected=f"broadcastable to {_shape_text(expected)}",
+            actual=actual,
+            fix=fix,
+        )
+    return expected
+
+
+def validate_detector_grid(
+    det_grid: tuple[Any, Any] | None,
+    detector: Detector,
+    *,
+    context: str,
+) -> None:
+    if det_grid is None:
+        return
+    nv, nu = validate_detector(detector, context)
+    expected_shape = (nv * nu,)
+    try:
+        Xr, Zr = det_grid
+    except Exception as exc:
+        raise ValueError(
+            f"{context}: det_grid has invalid values; expected a pair of detector-grid "
+            f"vectors, actual {type(det_grid).__name__}. Likely fix: call "
+            "get_detector_grid_device(detector) with matching detector metadata."
+        ) from exc
+    validate_optional_same_shape(
+        Xr,
+        expected_shape,
+        context=context,
+        name="det_grid[0]",
+        fix="call get_detector_grid_device(detector) with matching detector metadata.",
+    )
+    validate_optional_same_shape(
+        Zr,
+        expected_shape,
+        context=context,
+        name="det_grid[1]",
+        fix="call get_detector_grid_device(detector) with matching detector metadata.",
+    )

--- a/src/tomojax/recon/fbp.py
+++ b/src/tomojax/recon/fbp.py
@@ -10,6 +10,11 @@ import jax.numpy as jnp
 from ..core.geometry.base import Grid, Detector, Geometry
 from ..core.geometry.views import stack_view_poses
 from ..core.projector import backproject_view_T
+from ..core.validation import (
+    validate_grid,
+    validate_pose_stack,
+    validate_projection_stack,
+)
 from .filters import get_filter_np
 from ..utils.logging import progress_iter
 
@@ -289,10 +294,17 @@ def fbp(
     projections: (n_views, nv, nu) -> volume (nx, ny, nz).
     Memory-safe: filters and backprojects per view-batch.
     """
+    validate_grid(grid, "fbp grid")
+    n_views, _, _ = validate_projection_stack(
+        projections,
+        detector,
+        geometry=geometry,
+        context="fbp projections",
+    )
     proj = jnp.asarray(projections, dtype=jnp.float32)
-    n_views, nv, nu = proj.shape
     # Precompute poses once
     T_all = stack_view_poses(geometry, n_views)
+    validate_pose_stack(T_all, n_views, context="fbp geometry")
     requested_b = int(views_per_batch) if int(views_per_batch) > 0 else n_views
     b = max(1, min(requested_b, n_views))
     view_progress = iter(progress_iter(range(n_views), total=n_views, desc="FBP: views"))

--- a/src/tomojax/recon/fista_tv.py
+++ b/src/tomojax/recon/fista_tv.py
@@ -14,6 +14,15 @@ from ..core.projector import (
     get_detector_grid_device,
     sum_backproject_views_T,
 )
+from ..core.validation import (
+    validate_grid,
+    validate_optional_broadcastable_shape,
+    validate_optional_same_shape,
+    validate_pose_stack,
+    validate_projection_shape,
+    validate_projection_stack,
+    validate_volume,
+)
 from ._callbacks import LossCallback, emit_loss_callback_endpoints
 from ._tv_ops import div3, grad3
 
@@ -61,11 +70,24 @@ def grad_data_term(
 
     When grad_mode="auto", selects stream if the effective batch is 1, else batched.
     """
-    n_views = int(projections.shape[0])
-    nv = int(projections.shape[1])
-    nu = int(projections.shape[2])
+    validate_grid(grid, "grad_data_term grid")
+    n_views, nv, nu = validate_projection_stack(
+        projections,
+        detector,
+        geometry=geometry,
+        context="grad_data_term projections",
+    )
+    validate_volume(x, grid, context="grad_data_term", name="x")
+    validate_optional_broadcastable_shape(
+        vol_mask,
+        (grid.nx, grid.ny, grid.nz),
+        context="grad_data_term support",
+        name="vol_mask",
+        fix="use a volume mask broadcastable to shape (grid.nx, grid.ny, grid.nz).",
+    )
     if T_all is None:
         T_all = stack_view_poses(geometry, n_views)
+    validate_pose_stack(T_all, n_views, context="grad_data_term geometry")
 
     det_grid = get_detector_grid_device(detector)
     mask_arr = None if vol_mask is None else jnp.asarray(vol_mask, dtype=jnp.float32)
@@ -208,11 +230,24 @@ def data_term_value(
     vol_mask: Optional[jnp.ndarray] = None,
 ) -> jnp.ndarray:
     """Compute the data term ``1/2 Σ_i ||A_i x - y_i||^2`` without its gradient."""
-    n_views = int(projections.shape[0])
-    nv = int(projections.shape[1])
-    nu = int(projections.shape[2])
+    validate_grid(grid, "data_term_value grid")
+    n_views, nv, nu = validate_projection_stack(
+        projections,
+        detector,
+        geometry=geometry,
+        context="data_term_value projections",
+    )
+    validate_volume(x, grid, context="data_term_value", name="x")
+    validate_optional_broadcastable_shape(
+        vol_mask,
+        (grid.nx, grid.ny, grid.nz),
+        context="data_term_value support",
+        name="vol_mask",
+        fix="use a volume mask broadcastable to shape (grid.nx, grid.ny, grid.nz).",
+    )
     if T_all is None:
         T_all = stack_view_poses(geometry, n_views)
+    validate_pose_stack(T_all, n_views, context="data_term_value geometry")
 
     det_grid = get_detector_grid_device(detector)
 
@@ -315,9 +350,23 @@ def power_method_L(
     vol_mask: Optional[jnp.ndarray] = None,
 ) -> float:
     """Estimate Lipschitz constant of ∇f(x) ≈ ||A||^2 via power method on AᵀA."""
-    n_views, nv, nu = projections_shape
+    validate_grid(grid, "power_method_L grid")
+    n_views, nv, nu = validate_projection_shape(
+        projections_shape,
+        detector,
+        geometry=geometry,
+        context="power_method_L projections_shape",
+    )
+    validate_optional_broadcastable_shape(
+        vol_mask,
+        (grid.nx, grid.ny, grid.nz),
+        context="power_method_L support",
+        name="vol_mask",
+        fix="use a volume mask broadcastable to shape (grid.nx, grid.ny, grid.nz).",
+    )
     if T_all is None:
         T_all = stack_view_poses(geometry, n_views)
+    validate_pose_stack(T_all, n_views, context="power_method_L geometry")
     zero_proj = jnp.zeros((n_views, nv, nu), dtype=jnp.float32)
     num_iters = max(1, int(iters))
 
@@ -412,6 +461,22 @@ def fista_tv(
     """
     cfg = config
     vol_mask = cfg.support
+    validate_grid(grid, "fista_tv grid")
+    n_views, _, _ = validate_projection_stack(
+        projections,
+        detector,
+        geometry=geometry,
+        context="fista_tv projections",
+    )
+    validate_optional_broadcastable_shape(
+        vol_mask,
+        (grid.nx, grid.ny, grid.nz),
+        context="fista_tv support",
+        name="support",
+        fix="use a support mask broadcastable to shape (grid.nx, grid.ny, grid.nz).",
+    )
+    if init_x is not None:
+        validate_volume(init_x, grid, context="fista_tv init_x", name="init_x")
     x = (
         jnp.asarray(init_x, dtype=jnp.float32)
         if init_x is not None
@@ -421,8 +486,8 @@ def fista_tv(
     t = 1.0
     # Precompute poses once and thread them through the projector calls to avoid
     # repeatedly stacking in inner loops.
-    n_views = int(projections.shape[0])
     T_all = stack_view_poses(geometry, n_views)
+    validate_pose_stack(T_all, n_views, context="fista_tv geometry")
 
     L = cfg.L
     if L is None:

--- a/src/tomojax/recon/spdhg_tv.py
+++ b/src/tomojax/recon/spdhg_tv.py
@@ -14,6 +14,14 @@ from ..core.projector import (
     get_detector_grid_device,
     sum_backproject_views_T,
 )
+from ..core.validation import (
+    validate_grid,
+    validate_optional_broadcastable_shape,
+    validate_optional_same_shape,
+    validate_pose_stack,
+    validate_projection_stack,
+    validate_volume,
+)
 from ._callbacks import LossCallback, emit_loss_callback_endpoints
 from ._tv_ops import div3, grad3
 
@@ -173,12 +181,36 @@ def spdhg_tv(
     are eligible for callbacks; if a single logged sample exists, the callback
     fires once.
     """
+    validate_grid(grid, "spdhg_tv grid")
+    n_views, nv, nu = validate_projection_stack(
+        projections,
+        detector,
+        geometry=geometry,
+        context="spdhg_tv projections",
+    )
+    expected_proj_shape = (n_views, nv, nu)
+    validate_optional_same_shape(
+        weights,
+        expected_proj_shape,
+        context="spdhg_tv weights",
+        name="weights",
+        fix="use weights with the same shape as projections.",
+    )
+    validate_optional_broadcastable_shape(
+        config.support,
+        (grid.nx, grid.ny, grid.nz),
+        context="spdhg_tv support",
+        name="support",
+        fix="use a support mask broadcastable to shape (grid.nx, grid.ny, grid.nz).",
+    )
+    if init_x is not None:
+        validate_volume(init_x, grid, context="spdhg_tv init_x", name="init_x")
     y_meas = jnp.asarray(projections, dtype=jnp.float32)
-    n_views, nv, nu = int(y_meas.shape[0]), int(y_meas.shape[1]), int(y_meas.shape[2])
     W = jnp.ones_like(y_meas) if weights is None else jnp.asarray(weights, dtype=jnp.float32)
 
     # precompute per-view poses once (like your FISTA)
     T_all = stack_view_poses(geometry, n_views)
+    validate_pose_stack(T_all, n_views, context="spdhg_tv geometry")
     det_grid = get_detector_grid_device(detector)
 
     # batched projector over a chunk of views

--- a/src/tomojax/utils/memory.py
+++ b/src/tomojax/utils/memory.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Optional
 import os
 import math
@@ -8,12 +9,24 @@ from functools import lru_cache
 from .subprocesses import check_output_command
 
 
+@dataclass(frozen=True)
+class ViewsPerBatchEstimate:
+    """Memory-estimator result for callers that need fallback diagnostics."""
+
+    views_per_batch: int
+    free_bytes: Optional[int]
+    fallback_used: bool
+    fallback_reason: str | None = None
+
+
 def _bytes_per(dtype: str) -> int:
-    d = dtype.lower()
+    d = str(dtype).lower()
     if d in ("fp16", "float16", "half"):  # no int here; only used for gather
         return 2
     if d in ("bf16", "bfloat16"):
         return 2
+    if d in ("fp64", "float64", "double"):
+        return 8
     return 4  # default fp32
 
 
@@ -70,6 +83,8 @@ def estimate_views_per_batch(
     grid_nxyz: tuple[int, int, int],
     det_nuv: tuple[int, int],
     gather_dtype: str = "fp32",
+    projection_dtype: str = "fp32",
+    volume_dtype: str = "fp32",
     checkpoint_projector: bool = True,
     algo: str = "fbp",
     safety_frac: float = 0.75,
@@ -83,14 +98,50 @@ def estimate_views_per_batch(
     Returns at least 1 and at most n_views. Falls back to a conservative default (8 or all)
     if free memory cannot be determined.
     """
+    estimate = estimate_views_per_batch_info(
+        n_views=n_views,
+        grid_nxyz=grid_nxyz,
+        det_nuv=det_nuv,
+        gather_dtype=gather_dtype,
+        projection_dtype=projection_dtype,
+        volume_dtype=volume_dtype,
+        checkpoint_projector=checkpoint_projector,
+        algo=algo,
+        safety_frac=safety_frac,
+        free_bytes_override=free_bytes_override,
+        fallback_batch=8,
+    )
+    return estimate.views_per_batch
+
+
+def estimate_views_per_batch_info(
+    *,
+    n_views: int,
+    grid_nxyz: tuple[int, int, int],
+    det_nuv: tuple[int, int],
+    gather_dtype: str = "fp32",
+    projection_dtype: str = "fp32",
+    volume_dtype: str = "fp32",
+    checkpoint_projector: bool = True,
+    algo: str = "fbp",
+    safety_frac: float = 0.75,
+    free_bytes_override: Optional[int] = None,
+    fallback_batch: int = 8,
+) -> ViewsPerBatchEstimate:
+    """Estimate views-per-batch and report whether a fallback was required.
+
+    ``fallback_batch`` lets user-facing CLIs choose a stricter fallback while the
+    legacy integer API keeps its previous small-batch fallback behavior.
+    """
+    n_views_i = max(1, int(n_views))
     nx, ny, nz = map(int, grid_nxyz)
     nv, nu = map(int, det_nuv)
     rays = nv * nu
     vox = nx * ny * nz
 
-    # Base dtypes: projections and volumes are fp32; gather buffer can be reduced
-    proj_bytes = 4
-    vol_bytes = 4
+    # Base dtypes: projections and volumes default to fp32; gather can be reduced.
+    proj_bytes = _bytes_per(projection_dtype)
+    vol_bytes = _bytes_per(volume_dtype)
     gather_bytes = _bytes_per(gather_dtype)
 
     # Per-view footprint (rough upper bound)
@@ -112,6 +163,8 @@ def estimate_views_per_batch(
 
     # Empirical overhead fudge to cover extra buffers, remat, etc.
     fudge = 2.0 if algo.lower() == "fbp" else 4.0
+    if not checkpoint_projector:
+        fudge *= 1.25
 
     free_bytes = free_bytes_override
     if free_bytes is None:
@@ -119,11 +172,22 @@ def estimate_views_per_batch(
 
     if not free_bytes or free_bytes <= 0:
         # Fallback heuristics: pick a small-but-reasonable batch
-        return max(1, min(n_views, 8))
+        fallback = max(1, min(n_views_i, int(fallback_batch)))
+        return ViewsPerBatchEstimate(
+            views_per_batch=fallback,
+            free_bytes=free_bytes,
+            fallback_used=True,
+            fallback_reason="available memory could not be determined",
+        )
 
     budget = int(_normalized_safety_fraction(safety_frac) * free_bytes)
     if budget <= static_bytes:
-        return 1
+        return ViewsPerBatchEstimate(
+            views_per_batch=1,
+            free_bytes=int(free_bytes),
+            fallback_used=False,
+            fallback_reason=None,
+        )
 
     # Largest b such that per_batch(b) <= budget
     b_est = (budget - static_bytes) / float(algo_factor * fudge * per_view)
@@ -141,7 +205,13 @@ def estimate_views_per_batch(
     elif vox >= 256**3:
         cap_env = min(cap_env, 2)
     cap = max(1, cap_env)
-    return max(1, min(int(n_views), cap, b))
+    batch = max(1, min(n_views_i, cap, b))
+    return ViewsPerBatchEstimate(
+        views_per_batch=batch,
+        free_bytes=int(free_bytes),
+        fallback_used=False,
+        fallback_reason=None,
+    )
 
 
 def default_gather_dtype() -> str:

--- a/tests/test_align_quick.py
+++ b/tests/test_align_quick.py
@@ -127,6 +127,27 @@ def test_align_runs_with_cylindrical_volume_mask():
     assert np.isfinite(np.asarray(info["loss"])).all()
 
 
+def test_align_rejects_bad_init_params5_shape_with_expected_and_actual():
+    grid = Grid(nx=4, ny=4, nz=4, vx=1.0, vy=1.0, vz=1.0)
+    det = Detector(nu=4, nv=4, du=1.0, dv=1.0, det_center=(0.0, 0.0))
+    geom = ParallelGeometry(grid=grid, detector=det, thetas_deg=[0.0, 45.0, 90.0])
+    projs = jnp.zeros((3, det.nv, det.nu), dtype=jnp.float32)
+    bad_params = jnp.zeros((2, 5), dtype=jnp.float32)
+
+    with pytest.raises(
+        ValueError,
+        match=r"expected \(3, 5\).*actual \(2, 5\).*Likely fix",
+    ):
+        align(
+            geom,
+            grid,
+            det,
+            projs,
+            cfg=AlignConfig(outer_iters=1, recon_iters=1, recon_L=1.0),
+            init_params5=bad_params,
+        )
+
+
 def test_align_multires_counts_executed_outer_iters_without_observer():
     grid, det, geom, _, projs, _ = make_misaligned_case(6, 6, 6, 6, 4)
     cfg = AlignConfig(

--- a/tests/test_cli_entrypoints.py
+++ b/tests/test_cli_entrypoints.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import csv
 from contextlib import contextmanager
 import json
@@ -65,6 +66,16 @@ def test_recon_help_documents_quicklook_aliases(monkeypatch, capsys):
     captured = capsys.readouterr()
     assert "--quicklook" in captured.out
     assert "--save-preview" in captured.out
+
+
+def test_recon_views_per_batch_parser_accepts_auto_and_integers():
+    assert recon_cli._parse_views_per_batch("auto") == "auto"
+    assert recon_cli._parse_views_per_batch("AUTO") == "auto"
+    assert recon_cli._parse_views_per_batch("4") == 4
+    assert recon_cli._parse_views_per_batch("0") == 0
+
+    with pytest.raises(argparse.ArgumentTypeError):
+        recon_cli._parse_views_per_batch("fast")
 
 
 def test_simulate_main_builds_config_and_runs_writer(monkeypatch, tmp_path):

--- a/tests/test_cli_geometry_build.py
+++ b/tests/test_cli_geometry_build.py
@@ -14,6 +14,7 @@ from tomojax.data.geometry_meta import (
 from tomojax.data.io_hdf5 import LoadedNXTomo, NXTomoMetadata, load_nxtomo, save_nxtomo
 from tomojax.cli import recon as recon_cli
 from tomojax.core.geometry import Grid, ParallelGeometry
+from tomojax.utils.memory import ViewsPerBatchEstimate
 
 
 def _parallel_meta(**updates):
@@ -394,6 +395,266 @@ def test_recon_cli_writes_quicklook_png(monkeypatch: pytest.MonkeyPatch, tmp_pat
     assert preview.dtype == np.uint8
     assert preview.shape == (5, 4)
     assert preview.max() > preview.min()
+
+
+def test_recon_cli_auto_views_per_batch_uses_estimator_and_logs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    meta = _parallel_meta(
+        projections=np.zeros((5, 7, 9), dtype=np.float32),
+        thetas_deg=np.linspace(0.0, 180.0, 5, endpoint=False, dtype=np.float32),
+        image_key=np.zeros((5,), dtype=np.int32),
+    )
+    in_path = tmp_path / "auto_vpb_in.nxs"
+    out_path = tmp_path / "auto_vpb_out.nxs"
+    _write_recon_input(in_path, meta)
+    captured: dict[str, object] = {}
+
+    def fake_estimate(**kwargs):
+        captured["estimate_kwargs"] = kwargs
+        return ViewsPerBatchEstimate(
+            views_per_batch=3,
+            free_bytes=123_456,
+            fallback_used=False,
+        )
+
+    def fake_fbp(geom, recon_grid, detector, proj, **kwargs):
+        captured["fbp_kwargs"] = kwargs
+        return jnp.zeros((recon_grid.nx, recon_grid.ny, recon_grid.nz), dtype=jnp.float32)
+
+    caplog.set_level("INFO")
+    monkeypatch.setattr(recon_cli, "setup_logging", lambda: None)
+    monkeypatch.setattr(recon_cli, "log_jax_env", lambda: None)
+    monkeypatch.setattr(recon_cli, "transfer_guard_context", lambda mode: nullcontext())
+    monkeypatch.setattr(recon_cli, "estimate_views_per_batch_info", fake_estimate)
+    monkeypatch.setattr(recon_cli, "fbp", fake_fbp)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "recon",
+            "--data",
+            str(in_path),
+            "--algo",
+            "fbp",
+            "--roi",
+            "off",
+            "--gather-dtype",
+            "fp32",
+            "--views-per-batch",
+            "auto",
+            "--out",
+            str(out_path),
+        ],
+    )
+
+    recon_cli.main()
+
+    estimate_kwargs = captured["estimate_kwargs"]
+    assert estimate_kwargs["n_views"] == 5
+    assert estimate_kwargs["grid_nxyz"] == (8, 10, 6)
+    assert estimate_kwargs["det_nuv"] == (7, 9)
+    assert estimate_kwargs["algo"] == "fbp"
+    assert estimate_kwargs["gather_dtype"] == "fp32"
+    assert estimate_kwargs["fallback_batch"] == 1
+    assert captured["fbp_kwargs"]["views_per_batch"] == 3
+    assert "views_per_batch=3 (mode=auto, algo=fbp)" in caplog.text
+
+
+def test_recon_cli_auto_views_per_batch_warns_on_memory_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    meta = _parallel_meta(
+        projections=np.zeros((2, 7, 9), dtype=np.float32),
+        image_key=np.zeros((2,), dtype=np.int32),
+    )
+    in_path = tmp_path / "auto_vpb_fallback_in.nxs"
+    out_path = tmp_path / "auto_vpb_fallback_out.nxs"
+    _write_recon_input(in_path, meta)
+    captured: dict[str, object] = {}
+
+    def fake_estimate(**kwargs):
+        return ViewsPerBatchEstimate(
+            views_per_batch=1,
+            free_bytes=None,
+            fallback_used=True,
+            fallback_reason="available memory could not be determined",
+        )
+
+    def fake_fbp(geom, recon_grid, detector, proj, **kwargs):
+        captured["views_per_batch"] = kwargs["views_per_batch"]
+        return jnp.zeros((recon_grid.nx, recon_grid.ny, recon_grid.nz), dtype=jnp.float32)
+
+    caplog.set_level("WARNING")
+    monkeypatch.setattr(recon_cli, "setup_logging", lambda: None)
+    monkeypatch.setattr(recon_cli, "log_jax_env", lambda: None)
+    monkeypatch.setattr(recon_cli, "transfer_guard_context", lambda mode: nullcontext())
+    monkeypatch.setattr(recon_cli, "estimate_views_per_batch_info", fake_estimate)
+    monkeypatch.setattr(recon_cli, "fbp", fake_fbp)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "recon",
+            "--data",
+            str(in_path),
+            "--algo",
+            "fbp",
+            "--roi",
+            "off",
+            "--gather-dtype",
+            "fp32",
+            "--views-per-batch",
+            "auto",
+            "--out",
+            str(out_path),
+        ],
+    )
+
+    recon_cli.main()
+
+    assert captured["views_per_batch"] == 1
+    assert "Could not determine available memory" in caplog.text
+
+
+def test_recon_cli_explicit_views_per_batch_skips_estimator(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    meta = _parallel_meta(
+        projections=np.zeros((2, 7, 9), dtype=np.float32),
+        image_key=np.zeros((2,), dtype=np.int32),
+    )
+    in_path = tmp_path / "explicit_vpb_in.nxs"
+    out_path = tmp_path / "explicit_vpb_out.nxs"
+    _write_recon_input(in_path, meta)
+    captured: dict[str, object] = {}
+
+    def fail_estimate(**kwargs):
+        raise AssertionError("explicit views_per_batch should not call estimator")
+
+    def fake_fbp(geom, recon_grid, detector, proj, **kwargs):
+        captured["views_per_batch"] = kwargs["views_per_batch"]
+        return jnp.zeros((recon_grid.nx, recon_grid.ny, recon_grid.nz), dtype=jnp.float32)
+
+    monkeypatch.setattr(recon_cli, "setup_logging", lambda: None)
+    monkeypatch.setattr(recon_cli, "log_jax_env", lambda: None)
+    monkeypatch.setattr(recon_cli, "transfer_guard_context", lambda mode: nullcontext())
+    monkeypatch.setattr(recon_cli, "estimate_views_per_batch_info", fail_estimate)
+    monkeypatch.setattr(recon_cli, "fbp", fake_fbp)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "recon",
+            "--data",
+            str(in_path),
+            "--algo",
+            "fbp",
+            "--roi",
+            "off",
+            "--gather-dtype",
+            "fp32",
+            "--views-per-batch",
+            "4",
+            "--out",
+            str(out_path),
+        ],
+    )
+
+    recon_cli.main()
+
+    assert captured["views_per_batch"] == 4
+
+
+def test_recon_cli_default_views_per_batch_keeps_fbp_conservative(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    meta = _parallel_meta(
+        projections=np.zeros((2, 7, 9), dtype=np.float32),
+        image_key=np.zeros((2,), dtype=np.int32),
+    )
+    in_path = tmp_path / "default_vpb_in.nxs"
+    out_path = tmp_path / "default_vpb_out.nxs"
+    _write_recon_input(in_path, meta)
+    captured: dict[str, object] = {}
+
+    def fake_fbp(geom, recon_grid, detector, proj, **kwargs):
+        captured["views_per_batch"] = kwargs["views_per_batch"]
+        return jnp.zeros((recon_grid.nx, recon_grid.ny, recon_grid.nz), dtype=jnp.float32)
+
+    monkeypatch.setattr(recon_cli, "setup_logging", lambda: None)
+    monkeypatch.setattr(recon_cli, "log_jax_env", lambda: None)
+    monkeypatch.setattr(recon_cli, "transfer_guard_context", lambda mode: nullcontext())
+    monkeypatch.setattr(recon_cli, "fbp", fake_fbp)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "recon",
+            "--data",
+            str(in_path),
+            "--algo",
+            "fbp",
+            "--roi",
+            "off",
+            "--gather-dtype",
+            "fp32",
+            "--out",
+            str(out_path),
+        ],
+    )
+
+    recon_cli.main()
+
+    assert captured["views_per_batch"] == 1
+
+
+def test_recon_cli_spdhg_default_and_explicit_views_per_batch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    meta = _parallel_meta(
+        projections=np.zeros((2, 7, 9), dtype=np.float32),
+        image_key=np.zeros((2,), dtype=np.int32),
+    )
+    captured: list[int] = []
+
+    def fake_spdhg(geom, recon_grid, detector, proj, *, init_x, config):
+        captured.append(config.views_per_batch)
+        vol = jnp.zeros((recon_grid.nx, recon_grid.ny, recon_grid.nz), dtype=jnp.float32)
+        return vol, {}
+
+    monkeypatch.setattr(recon_cli, "setup_logging", lambda: None)
+    monkeypatch.setattr(recon_cli, "log_jax_env", lambda: None)
+    monkeypatch.setattr(recon_cli, "transfer_guard_context", lambda mode: nullcontext())
+    monkeypatch.setattr(recon_cli, "spdhg_tv", fake_spdhg)
+
+    for suffix, extra_args in (("default", []), ("explicit", ["--views-per-batch", "5"])):
+        in_path = tmp_path / f"spdhg_{suffix}_vpb_in.nxs"
+        out_path = tmp_path / f"spdhg_{suffix}_vpb_out.nxs"
+        _write_recon_input(in_path, meta)
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "recon",
+                "--data",
+                str(in_path),
+                "--algo",
+                "spdhg",
+                "--roi",
+                "off",
+                "--gather-dtype",
+                "fp32",
+                "--out",
+                str(out_path),
+                *extra_args,
+            ],
+        )
+        recon_cli.main()
+
+    assert captured == [16, 5]
 
 
 def test_recon_build_geometry_keeps_nominal_geometry_for_saved_alignment_metadata():

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -73,3 +73,42 @@ def test_host_available_memory_bytes_returns_none_without_sysconf_support(monkey
     monkeypatch.setattr(memory_utils.os, "sysconf_names", {})
 
     assert memory_utils._host_available_memory_bytes() is None
+
+
+def test_estimate_views_per_batch_info_reports_safe_fallback():
+    estimate = memory_utils.estimate_views_per_batch_info(
+        n_views=10,
+        grid_nxyz=(16, 16, 16),
+        det_nuv=(8, 8),
+        free_bytes_override=0,
+        fallback_batch=1,
+    )
+
+    assert estimate.views_per_batch == 1
+    assert estimate.free_bytes == 0
+    assert estimate.fallback_used is True
+    assert estimate.fallback_reason is not None
+
+
+def test_estimate_views_per_batch_info_respects_cap_and_dtype_footprint(monkeypatch):
+    monkeypatch.setenv("TOMOJAX_MAX_VIEWS_PER_BATCH", "128")
+
+    lower_footprint = memory_utils.estimate_views_per_batch_info(
+        n_views=128,
+        grid_nxyz=(32, 32, 32),
+        det_nuv=(256, 256),
+        gather_dtype="fp16",
+        free_bytes_override=20_000_000,
+    )
+    higher_footprint = memory_utils.estimate_views_per_batch_info(
+        n_views=128,
+        grid_nxyz=(32, 32, 32),
+        det_nuv=(256, 256),
+        gather_dtype="fp32",
+        free_bytes_override=20_000_000,
+    )
+
+    assert 1 <= higher_footprint.views_per_batch <= lower_footprint.views_per_batch <= 128
+    assert higher_footprint.views_per_batch < lower_footprint.views_per_batch
+    assert lower_footprint.fallback_used is False
+    assert higher_footprint.fallback_used is False

--- a/tests/test_projector.py
+++ b/tests/test_projector.py
@@ -38,6 +38,28 @@ def test_forward_project_uniform_volume_returns_path_length():
     assert np.allclose(np.asarray(proj), expected, atol=1e-4)
 
 
+def test_forward_project_rejects_bad_volume_shape_with_expected_and_actual():
+    grid, det, geom, _ = make_aligned_case(8, 8, 8)
+    bad_vol = jnp.zeros((grid.nx, grid.ny), dtype=jnp.float32)
+
+    with pytest.raises(
+        ValueError,
+        match=r"expected .*=\(8, 8, 8\).*actual \(8, 8\).*Likely fix",
+    ):
+        forward_project_view(geom, grid, det, bad_vol, view_index=0)
+
+
+def test_backproject_rejects_bad_detector_image_shape_with_expected_and_actual():
+    grid, det, _, _ = make_aligned_case(8, 8, 8)
+    bad_image = jnp.zeros((det.nv + 1, det.nu), dtype=jnp.float32)
+
+    with pytest.raises(
+        ValueError,
+        match=r"expected .*=\(8, 8\).*actual \(9, 8\).*Likely fix",
+    ):
+        backproject_view_T(jnp.eye(4, dtype=jnp.float32), grid, det, bad_image)
+
+
 @pytest.mark.parametrize("gather_dtype", ["fp32", "bf16", "fp16"])
 def test_adjoint_small_case(gather_dtype: str):
     grid, det, geom, vol = make_aligned_case(8, 8, 8)

--- a/tests/test_recon.py
+++ b/tests/test_recon.py
@@ -73,6 +73,45 @@ def test_fbp_default_scaling_recovers_reasonable_absolute_intensity():
     assert roi_mean == pytest.approx(1.0, rel=0.1, abs=0.1)
 
 
+def test_fbp_rejects_angle_projection_count_mismatch():
+    grid = Grid(nx=4, ny=4, nz=4, vx=1.0, vy=1.0, vz=1.0)
+    det = Detector(nu=4, nv=4, du=1.0, dv=1.0, det_center=(0.0, 0.0))
+    geom = ParallelGeometry(grid=grid, detector=det, thetas_deg=[0.0, 45.0, 90.0])
+    projs = jnp.zeros((2, det.nv, det.nu), dtype=jnp.float32)
+
+    with pytest.raises(
+        ValueError,
+        match=r"expected .*=\(3, 4, 4\).*actual \(2, 4, 4\).*Likely fix",
+    ):
+        fbp(geom, grid, det, projs)
+
+
+def test_fbp_rejects_detector_shape_mismatch():
+    grid = Grid(nx=4, ny=4, nz=4, vx=1.0, vy=1.0, vz=1.0)
+    det = Detector(nu=4, nv=4, du=1.0, dv=1.0, det_center=(0.0, 0.0))
+    geom = ParallelGeometry(grid=grid, detector=det, thetas_deg=[0.0, 45.0, 90.0])
+    projs = jnp.zeros((3, det.nv + 1, det.nu), dtype=jnp.float32)
+
+    with pytest.raises(
+        ValueError,
+        match=r"expected .*=\(3, 4, 4\).*actual \(3, 5, 4\).*Likely fix",
+    ):
+        fbp(geom, grid, det, projs)
+
+
+def test_fista_rejects_invalid_reconstruction_grid_shape():
+    grid = Grid(nx=0, ny=4, nz=4, vx=1.0, vy=1.0, vz=1.0)
+    det = Detector(nu=4, nv=4, du=1.0, dv=1.0, det_center=(0.0, 0.0))
+    geom = ParallelGeometry(grid=grid, detector=det, thetas_deg=[0.0])
+    projs = jnp.zeros((1, det.nv, det.nu), dtype=jnp.float32)
+
+    with pytest.raises(
+        ValueError,
+        match=r"positive integer \(nx, ny, nz\).*actual \(0, 4, 4\).*Likely fix",
+    ):
+        fista_tv(geom, grid, det, projs, config=FistaConfig(iters=1, L=1.0))
+
+
 def test_fista_loss_decreases():
     grid, det, geom, vol, projs = make_simple_case(12, 12, 12, 16)
     x, info = fista_tv(

--- a/tests/test_recon_math_fixes.py
+++ b/tests/test_recon_math_fixes.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
-
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -65,8 +63,8 @@ def test_fista_reports_objective_at_primal_iterate_not_momentum(monkeypatch: pyt
         def pose_for_view(self, i: int):
             return jnp.eye(4, dtype=jnp.float32)
 
-    grid = SimpleNamespace(nx=1, ny=1, nz=1)
-    detector = SimpleNamespace()
+    grid = Grid(nx=1, ny=1, nz=1, vx=1.0, vy=1.0, vz=1.0)
+    detector = Detector(nu=1, nv=1, du=1.0, dv=1.0)
     projections = jnp.zeros((1, 1, 1), dtype=jnp.float32)
 
     _, info = fista_mod.fista_tv(


### PR DESCRIPTION
## Summary
- Add `--views-per-batch auto` to `tomojax-recon` and resolve batch sizes after ROI/grid selection using the memory estimator
- Keep explicit integer batch sizes unchanged, preserve conservative defaults, and warn with a safe fallback when memory cannot be determined
- Extend estimator coverage and add CLI tests for parsing, logging, fallback behavior, and explicit/default batching paths

## Testing
- `uv run pytest -q tests/test_memory.py tests/test_cli_entrypoints.py tests/test_cli_geometry_build.py tests/test_fbp_batching.py`
- `uv run ruff check src/tomojax/utils/memory.py src/tomojax/cli/recon.py tests/test_memory.py tests/test_cli_entrypoints.py tests/test_cli_geometry_build.py`