### PR TITLE
Add smooth pose models for alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ Alignment optimises per-view parameters in `[alpha, beta, phi, dx, dz]` order by
 Use `--optimise-dofs dx,dz` for translation-only 2-DOF runs, `--freeze-dofs phi`
 for a common 4-DOF run, or omit DOF flags for full 5-DOF alignment. Outputs still
 store all five columns; inactive columns are held fixed at their initial values.
+Use bounds such as `--bounds dx=-20:20,dz=-20:20,alpha=-0.05:0.05` to keep active
+DOFs inside physical limits; rotations are radians and translations are world units.
 
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -212,6 +212,11 @@ Troubleshooting tips live in `docs/faq_troubleshooting.md`.
 3. Transfer parameters across levels and rescale
 4. Monitor objective and parameter deltas for convergence/early stop
 
+Alignment optimises per-view parameters in `[alpha, beta, phi, dx, dz]` order by default.
+Use `--optimise-dofs dx,dz` for translation-only 2-DOF runs, `--freeze-dofs phi`
+for a common 4-DOF run, or omit DOF flags for full 5-DOF alignment. Outputs still
+store all five columns; inactive columns are held fixed at their initial values.
+
 
 ## Notes
 

--- a/docs/align_config.toml
+++ b/docs/align_config.toml
@@ -11,6 +11,12 @@ lambda_tv = 0.003
 levels = [4, 2, 1]
 opt_method = "gn"
 gn_damping = 0.001
+# Common DOF selections:
+#   2-DOF translation-only alignment: optimise_dofs = ["dx", "dz"]
+#   4-DOF with in-plane spin fixed: freeze_dofs = ["phi"]
+#   5-DOF full alignment: omit both keys, or set all names explicitly.
+# optimise_dofs = ["dx", "dz"]
+# freeze_dofs = ["phi"]
 gather_dtype = "auto"
 checkpoint_projector = true
 log_summary = true

--- a/docs/align_config.toml
+++ b/docs/align_config.toml
@@ -20,6 +20,12 @@ gn_damping = 0.001
 # Optional finite parameter bounds by DOF. Rotations are radians; translations
 # are world units. Omitted DOFs are unconstrained.
 # bounds = { dx = [-20, 20], dz = [-20, 20], alpha = [-0.05, 0.05] }
+# Optional smooth motion model for drift-like or mechanically smooth alignment.
+# The default per_view model optimises one independent 5-DOF vector per view.
+# Use spline or polynomial on noisy data when per-view fitting overfits view-local noise.
+# pose_model = "spline"
+# knot_spacing = 12
+# degree = 3
 gather_dtype = "auto"
 checkpoint_projector = true
 log_summary = true

--- a/docs/align_config.toml
+++ b/docs/align_config.toml
@@ -17,6 +17,9 @@ gn_damping = 0.001
 #   5-DOF full alignment: omit both keys, or set all names explicitly.
 # optimise_dofs = ["dx", "dz"]
 # freeze_dofs = ["phi"]
+# Optional finite parameter bounds by DOF. Rotations are radians; translations
+# are world units. Omitted DOFs are unconstrained.
+# bounds = { dx = [-20, 20], dz = [-20, 20], alpha = [-0.05, 0.05] }
 gather_dtype = "auto"
 checkpoint_projector = true
 log_summary = true

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -168,6 +168,7 @@ python -m tomojax.cli.align [--config <config.toml>] --data <in.nxs> \
   [--tv-prox-iters <int>] \
   [--lr-rot <float>] [--lr-trans <float>] \
   [--opt-method gd|gn] [--gn-damping <float>] \
+  [--optimise-dofs <names>] [--freeze-dofs <names>] \
   [--early-stop|--no-early-stop] [--early-stop-rel <float>] [--early-stop-patience <int>] \
   [--w-rot <float>] [--w-trans <float>] [--seed-translations] \
   [--levels <ints...>] [--gather-dtype fp32|bf16|fp16] \
@@ -180,6 +181,7 @@ Key options
 - Config: `--config docs/align_config.toml` loads flat TOML defaults. Explicit CLI flags override file values, including list values such as `--levels 2 1` and booleans such as `--no-checkpoint-projector`.
 - Outer/inner loops: `--outer-iters` (5), `--recon-iters` (10), `--lambda-tv` (0.005), `--tv-prox-iters` (10; increase to 20–30 for noisy data).
 - Alignment step: gradient descent (`--lr-rot`, `--lr-trans`) or Gauss‑Newton (`--opt-method gn`, `--gn-damping`).
+- Active DOFs: choose from `alpha`, `beta`, `phi`, `dx`, `dz`. By default all five are optimised. Use `--optimise-dofs dx,dz` for translation-only alignment, or `--freeze-dofs phi` to keep selected parameters fixed at their initial values.
 - Early stopping (alignment across outers):
   - Enable/disable: `--early-stop` (default) or `--no-early-stop`.
   - Threshold and patience: `--early-stop-rel` (default 1e-3), `--early-stop-patience` (default 2).
@@ -194,6 +196,7 @@ Key options
 
 Notes
 - The `.nxs` output still stores the final alignment parameters; JSON/CSV sidecars are optional convenience exports for plotting and reproducibility.
+- DOF selection does not change the saved parameter format: outputs still use five columns in `[alpha, beta, phi, dx, dz]` order, with inactive columns held fixed.
 - The align CLI initializes a persistent JAX compilation cache automatically. Set `TOMOJAX_JAX_CACHE_DIR` to control the cache location.
 
 Examples
@@ -214,6 +217,21 @@ uv run tomojax-align --data data/sim_misaligned.nxs \
   --outer-iters 6 --recon-iters 30 --lambda-tv 0.005 \
   --opt-method gd --lr-rot 3e-3 --lr-trans 1e-1 \
   --out out/align_gd.nxs --progress
+
+# 2-DOF translation-only alignment
+uv run tomojax-align --data data/sim_misaligned.nxs \
+  --levels 4 2 1 --opt-method gn --optimise-dofs dx,dz \
+  --out out/align_translation_only.nxs
+
+# 4-DOF alignment with in-plane spin fixed
+uv run tomojax-align --data data/sim_misaligned.nxs \
+  --levels 4 2 1 --opt-method gn --freeze-dofs phi \
+  --out out/align_no_phi.nxs
+
+# 5-DOF full alignment is the default; this explicit form is equivalent
+uv run tomojax-align --data data/sim_misaligned.nxs \
+  --levels 4 2 1 --opt-method gn --optimise-dofs alpha,beta,phi,dx,dz \
+  --out out/align_full_5dof.nxs
 
 # TOML config with an explicit CLI override
 uv run tomojax-align --config docs/align_config.toml --levels 2 1

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -170,6 +170,7 @@ python -m tomojax.cli.align [--config <config.toml>] --data <in.nxs> \
   [--opt-method gd|gn] [--gn-damping <float>] \
   [--optimise-dofs <names>] [--freeze-dofs <names>] [--bounds <spec>] \
   [--early-stop|--no-early-stop] [--early-stop-rel <float>] [--early-stop-patience <int>] \
+  [--pose-model per_view|polynomial|spline] [--knot-spacing <int>] [--degree <int>] \
   [--w-rot <float>] [--w-trans <float>] [--seed-translations] \
   [--levels <ints...>] [--gather-dtype fp32|bf16|fp16] \
   [--checkpoint-projector|--no-checkpoint-projector] [--recon-L <float>] [--log-summary] \
@@ -183,10 +184,11 @@ Key options
 - Alignment step: gradient descent (`--lr-rot`, `--lr-trans`) or Gauss‑Newton (`--opt-method gn`, `--gn-damping`).
 - Active DOFs: choose from `alpha`, `beta`, `phi`, `dx`, `dz`. By default all five are optimised. Use `--optimise-dofs dx,dz` for translation-only alignment, or `--freeze-dofs phi` to keep selected parameters fixed at their initial values.
 - Parameter bounds: `--bounds dx=-20:20,dz=-20:20,alpha=-0.05:0.05` clips named DOFs after each update. Rotations (`alpha`, `beta`, `phi`) are in radians; translations (`dx`, `dz`) are in world units. Omitted DOFs are unconstrained, and frozen DOFs stay fixed even if a bound is supplied for them.
+- Pose model: `--pose-model per_view` (default) optimises one independent parameter vector per view. `--pose-model spline --knot-spacing N --degree 3` optimises smooth knot trajectories and expands them back to per-view parameters before projection. `--pose-model polynomial --degree D` fits each active DOF as a low-degree polynomial over the scan coordinate.
 - Early stopping (alignment across outers):
   - Enable/disable: `--early-stop` (default) or `--no-early-stop`.
   - Threshold and patience: `--early-stop-rel` (default 1e-3), `--early-stop-patience` (default 2).
-- Smoothness across views: `--w-rot`, `--w-trans` (default 1e‑3 in CLI).
+- Smoothness across views: `--w-rot`, `--w-trans` (default 1e‑3 in CLI) add a second-difference prior on the expanded per-view parameters. Smooth pose models usually need less explicit prior strength because the basis already reduces freedom.
 - Multi‑resolution: `--levels 4 2 1` for coarse→fine; optional `--seed-translations` uses phase correlation at the coarsest level.
 - Memory/performance: same knobs as recon (gather dtype and checkpointing).
 - `--recon-L`: fixes the Lipschitz constant to skip per‑level power‑method if you already know a good bound.
@@ -198,6 +200,7 @@ Key options
 Notes
 - The `.nxs` output still stores the final alignment parameters; JSON/CSV sidecars are optional convenience exports for plotting and reproducibility.
 - DOF selection does not change the saved parameter format: outputs still use five columns in `[alpha, beta, phi, dx, dz]` order, with inactive columns held fixed.
+- Smooth motion models are best for slow drift, stage sag, thermal/mechanical trends, or noisy data where independent per-view parameters overfit. Keep `per_view` for abrupt shifts, dropped-view artifacts, or genuinely view-local motion.
 - The align CLI initializes a persistent JAX compilation cache automatically. Set `TOMOJAX_JAX_CACHE_DIR` to control the cache location.
 
 Examples
@@ -234,6 +237,18 @@ uv run tomojax-align --data data/sim_misaligned.nxs \
   --levels 4 2 1 --opt-method gn \
   --bounds dx=-20:20,dz=-20:20,alpha=-0.05:0.05 \
   --out out/align_bounded.nxs
+
+# Smooth spline model for noisy drift-like motion
+uv run tomojax-align --data data/sim_misaligned_poisson.nxs \
+  --levels 4 2 1 --opt-method gn \
+  --pose-model spline --knot-spacing 12 --degree 3 \
+  --out out/align_spline.nxs
+
+# Low-order polynomial model for simple scan-length drift
+uv run tomojax-align --data data/sim_misaligned.nxs \
+  --levels 4 2 1 --opt-method gn \
+  --pose-model polynomial --degree 2 \
+  --out out/align_poly2.nxs
 
 # 5-DOF full alignment is the default; this explicit form is equivalent
 uv run tomojax-align --data data/sim_misaligned.nxs \

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -168,7 +168,7 @@ python -m tomojax.cli.align [--config <config.toml>] --data <in.nxs> \
   [--tv-prox-iters <int>] \
   [--lr-rot <float>] [--lr-trans <float>] \
   [--opt-method gd|gn] [--gn-damping <float>] \
-  [--optimise-dofs <names>] [--freeze-dofs <names>] \
+  [--optimise-dofs <names>] [--freeze-dofs <names>] [--bounds <spec>] \
   [--early-stop|--no-early-stop] [--early-stop-rel <float>] [--early-stop-patience <int>] \
   [--w-rot <float>] [--w-trans <float>] [--seed-translations] \
   [--levels <ints...>] [--gather-dtype fp32|bf16|fp16] \
@@ -182,6 +182,7 @@ Key options
 - Outer/inner loops: `--outer-iters` (5), `--recon-iters` (10), `--lambda-tv` (0.005), `--tv-prox-iters` (10; increase to 20–30 for noisy data).
 - Alignment step: gradient descent (`--lr-rot`, `--lr-trans`) or Gauss‑Newton (`--opt-method gn`, `--gn-damping`).
 - Active DOFs: choose from `alpha`, `beta`, `phi`, `dx`, `dz`. By default all five are optimised. Use `--optimise-dofs dx,dz` for translation-only alignment, or `--freeze-dofs phi` to keep selected parameters fixed at their initial values.
+- Parameter bounds: `--bounds dx=-20:20,dz=-20:20,alpha=-0.05:0.05` clips named DOFs after each update. Rotations (`alpha`, `beta`, `phi`) are in radians; translations (`dx`, `dz`) are in world units. Omitted DOFs are unconstrained, and frozen DOFs stay fixed even if a bound is supplied for them.
 - Early stopping (alignment across outers):
   - Enable/disable: `--early-stop` (default) or `--no-early-stop`.
   - Threshold and patience: `--early-stop-rel` (default 1e-3), `--early-stop-patience` (default 2).
@@ -227,6 +228,12 @@ uv run tomojax-align --data data/sim_misaligned.nxs \
 uv run tomojax-align --data data/sim_misaligned.nxs \
   --levels 4 2 1 --opt-method gn --freeze-dofs phi \
   --out out/align_no_phi.nxs
+
+# Bounded translations and one rotation, preserving unconstrained behavior for other DOFs
+uv run tomojax-align --data data/sim_misaligned.nxs \
+  --levels 4 2 1 --opt-method gn \
+  --bounds dx=-20:20,dz=-20:20,alpha=-0.05:0.05 \
+  --out out/align_bounded.nxs
 
 # 5-DOF full alignment is the default; this explicit form is equivalent
 uv run tomojax-align --data data/sim_misaligned.nxs \

--- a/src/tomojax/align/dofs.py
+++ b/src/tomojax/align/dofs.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping, Sequence
+import math
 
 import jax.numpy as jnp
 
 
 DOF_NAMES = ("alpha", "beta", "phi", "dx", "dz")
 DOF_INDEX = {name: idx for idx, name in enumerate(DOF_NAMES)}
+type DofBounds = tuple[tuple[str, float, float], ...]
 
 
 def _iter_dof_tokens(value: str | Iterable[str] | None) -> Iterable[str]:
@@ -42,6 +44,123 @@ def normalize_dofs(
         seen.add(name)
         names.append(name)
     return tuple(names)
+
+
+def _parse_bound_float(raw: object, *, option_name: str, dof_name: str) -> float:
+    try:
+        value = float(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"Invalid alignment bound for {option_name} {dof_name!r}: "
+            f"{raw!r} is not numeric"
+        ) from exc
+    if not math.isfinite(value):
+        raise ValueError(
+            f"Invalid alignment bound for {option_name} {dof_name!r}: "
+            f"{raw!r} must be finite"
+        )
+    return value
+
+
+def _validate_bound_name(raw_name: object, *, option_name: str) -> str:
+    name = str(raw_name).strip().lower()
+    valid = ", ".join(DOF_NAMES)
+    if not name:
+        raise ValueError(f"Missing alignment DOF name for {option_name}; valid DOFs: {valid}")
+    if name not in DOF_INDEX:
+        raise ValueError(
+            f"Unknown alignment DOF for {option_name}: {name!r}; valid DOFs: {valid}"
+        )
+    return name
+
+
+def _parse_bound_pair(raw_pair: object, *, option_name: str, dof_name: str) -> tuple[float, float]:
+    if isinstance(raw_pair, str):
+        if ":" not in raw_pair:
+            raise ValueError(
+                f"Invalid alignment bounds for {option_name} {dof_name!r}: "
+                "expected lower:upper"
+            )
+        lower_raw, upper_raw = raw_pair.split(":", 1)
+        pair: Sequence[object] = (lower_raw.strip(), upper_raw.strip())
+    elif isinstance(raw_pair, Sequence):
+        pair = raw_pair
+    else:
+        raise ValueError(
+            f"Invalid alignment bounds for {option_name} {dof_name!r}: "
+            "expected a two-item sequence or lower:upper string"
+        )
+
+    if len(pair) != 2:
+        raise ValueError(
+            f"Invalid alignment bounds for {option_name} {dof_name!r}: "
+            f"expected 2 values, got {len(pair)}"
+        )
+    lower = _parse_bound_float(pair[0], option_name=option_name, dof_name=dof_name)
+    upper = _parse_bound_float(pair[1], option_name=option_name, dof_name=dof_name)
+    if lower >= upper:
+        raise ValueError(
+            f"Invalid alignment bounds for {option_name} {dof_name!r}: "
+            f"lower bound {lower:g} must be less than upper bound {upper:g}"
+        )
+    return lower, upper
+
+
+def _iter_bound_items(value: object, *, option_name: str) -> Iterable[tuple[object, object]]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        items: list[tuple[object, object]] = []
+        for raw_token in value.split(","):
+            token = raw_token.strip()
+            if not token:
+                continue
+            if "=" not in token:
+                raise ValueError(
+                    f"Invalid alignment bounds for {option_name}: "
+                    f"{token!r} must use DOF=lower:upper"
+                )
+            raw_name, raw_pair = token.split("=", 1)
+            items.append((raw_name, raw_pair))
+        return items
+    if isinstance(value, Mapping):
+        return value.items()
+    if isinstance(value, Iterable):
+        items = []
+        for item in value:
+            if not isinstance(item, Sequence) or isinstance(item, str) or len(item) != 3:
+                raise ValueError(
+                    f"Invalid alignment bounds for {option_name}: "
+                    "expected entries as (DOF, lower, upper)"
+                )
+            items.append((item[0], (item[1], item[2])))
+        return items
+    raise ValueError(
+        f"Invalid alignment bounds for {option_name}: "
+        "expected a string, mapping, sequence, or None"
+    )
+
+
+def normalize_bounds(value: object, *, option_name: str = "bounds") -> DofBounds:
+    """Normalize finite per-DOF alignment bounds from CLI/config/Python inputs."""
+    parsed: dict[str, tuple[float, float]] = {}
+    for raw_name, raw_pair in _iter_bound_items(value, option_name=option_name):
+        name = _validate_bound_name(raw_name, option_name=option_name)
+        if name in parsed:
+            raise ValueError(f"Duplicate alignment bounds for {option_name}: {name!r}")
+        parsed[name] = _parse_bound_pair(raw_pair, option_name=option_name, dof_name=name)
+    return tuple((name, *parsed[name]) for name in DOF_NAMES if name in parsed)
+
+
+def bounds_vectors(bounds: DofBounds) -> tuple[jnp.ndarray, jnp.ndarray]:
+    """Build 5-column lower/upper bound vectors for normalized per-DOF bounds."""
+    lower = jnp.full((len(DOF_NAMES),), -jnp.inf, dtype=jnp.float32)
+    upper = jnp.full((len(DOF_NAMES),), jnp.inf, dtype=jnp.float32)
+    for name, lo, hi in bounds:
+        idx = DOF_INDEX[name]
+        lower = lower.at[idx].set(jnp.float32(lo))
+        upper = upper.at[idx].set(jnp.float32(hi))
+    return lower, upper
 
 
 def active_dofs(

--- a/src/tomojax/align/dofs.py
+++ b/src/tomojax/align/dofs.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import jax.numpy as jnp
+
+
+DOF_NAMES = ("alpha", "beta", "phi", "dx", "dz")
+DOF_INDEX = {name: idx for idx, name in enumerate(DOF_NAMES)}
+
+
+def _iter_dof_tokens(value: str | Iterable[str] | None) -> Iterable[str]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return value.split(",")
+    tokens: list[str] = []
+    for item in value:
+        tokens.extend(str(item).split(","))
+    return tokens
+
+
+def normalize_dofs(
+    value: str | Iterable[str] | None,
+    *,
+    option_name: str = "dofs",
+) -> tuple[str, ...]:
+    """Normalize named alignment DOFs from CLI/config/Python inputs."""
+    names: list[str] = []
+    seen: set[str] = set()
+    valid = ", ".join(DOF_NAMES)
+    for raw in _iter_dof_tokens(value):
+        name = str(raw).strip().lower()
+        if not name:
+            continue
+        if name not in DOF_INDEX:
+            raise ValueError(
+                f"Unknown alignment DOF for {option_name}: {name!r}; valid DOFs: {valid}"
+            )
+        if name in seen:
+            raise ValueError(f"Duplicate alignment DOF for {option_name}: {name!r}")
+        seen.add(name)
+        names.append(name)
+    return tuple(names)
+
+
+def active_dofs(
+    *,
+    optimise_dofs: str | Iterable[str] | None = None,
+    freeze_dofs: str | Iterable[str] | None = None,
+) -> tuple[str, ...]:
+    """Return effective active DOFs after applying optimise and freeze selections."""
+    optimise = (
+        None
+        if optimise_dofs is None
+        else normalize_dofs(optimise_dofs, option_name="optimise_dofs")
+    )
+    freeze = normalize_dofs(freeze_dofs, option_name="freeze_dofs")
+    frozen = set(freeze)
+    base = DOF_NAMES if optimise is None else optimise
+    active = tuple(name for name in base if name not in frozen)
+    if not active:
+        raise ValueError(
+            "No active alignment DOFs remain after applying optimise_dofs/freeze_dofs; "
+            f"valid DOFs: {', '.join(DOF_NAMES)}"
+        )
+    return active
+
+
+def active_dof_mask(
+    *,
+    optimise_dofs: str | Iterable[str] | None = None,
+    freeze_dofs: str | Iterable[str] | None = None,
+) -> tuple[bool, bool, bool, bool, bool]:
+    """Build a 5-column boolean mask for active alignment DOFs."""
+    active = set(active_dofs(optimise_dofs=optimise_dofs, freeze_dofs=freeze_dofs))
+    return tuple(name in active for name in DOF_NAMES)  # type: ignore[return-value]
+
+
+def active_dof_mask_array(
+    *,
+    optimise_dofs: str | Iterable[str] | None = None,
+    freeze_dofs: str | Iterable[str] | None = None,
+) -> jnp.ndarray:
+    """Build a float32 JAX mask for active alignment DOFs."""
+    return jnp.asarray(
+        active_dof_mask(optimise_dofs=optimise_dofs, freeze_dofs=freeze_dofs),
+        dtype=jnp.float32,
+    )

--- a/src/tomojax/align/motion_models.py
+++ b/src/tomojax/align/motion_models.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Sequence
+
+import numpy as np
+import jax.numpy as jnp
+
+from .dofs import DOF_INDEX
+
+
+type PoseModelName = Literal["per_view", "polynomial", "spline"]
+
+
+@dataclass(frozen=True)
+class PoseMotionModel:
+    """Low-dimensional linear model for per-view 5-DOF alignment parameters."""
+
+    name: PoseModelName
+    basis: jnp.ndarray
+    basis_pinv: jnp.ndarray
+    active_indices: tuple[int, ...]
+    active_names: tuple[str, ...]
+    frozen_params5: jnp.ndarray
+
+    @property
+    def n_views(self) -> int:
+        return int(self.basis.shape[0])
+
+    @property
+    def n_basis(self) -> int:
+        return int(self.basis.shape[1])
+
+    @property
+    def n_active(self) -> int:
+        return len(self.active_indices)
+
+    @property
+    def variable_count(self) -> int:
+        return self.n_basis * self.n_active
+
+    @property
+    def per_view_variable_count(self) -> int:
+        return self.n_views * self.n_active
+
+
+def scan_coordinate_from_geometry(geometry: object, n_views: int) -> np.ndarray:
+    """Return a normalized scan coordinate for pose models.
+
+    Use geometry angles when they are present and monotonic; otherwise fall back
+    to the view index. The returned coordinate is always in [-1, 1].
+    """
+    coord: np.ndarray | None = None
+    raw_thetas = getattr(geometry, "thetas_deg", None)
+    if raw_thetas is not None:
+        try:
+            arr = np.asarray(raw_thetas, dtype=np.float64)
+            if arr.shape == (int(n_views),) and np.all(np.isfinite(arr)):
+                diffs = np.diff(arr)
+                if arr.size <= 1 or np.all(diffs > 0.0):
+                    coord = arr
+        except Exception:
+            coord = None
+    if coord is None:
+        coord = np.arange(int(n_views), dtype=np.float64)
+    return _normalize_coordinate(coord)
+
+
+def build_pose_motion_model(
+    *,
+    pose_model: str,
+    n_views: int,
+    active_dofs: Sequence[str],
+    frozen_params5: jnp.ndarray,
+    scan_coordinate: np.ndarray | None = None,
+    knot_spacing: int = 8,
+    degree: int = 3,
+) -> PoseMotionModel:
+    """Build a linear basis model for alignment parameter trajectories."""
+    name = _normalize_pose_model(pose_model)
+    if int(n_views) <= 0:
+        raise ValueError("n_views must be positive for pose motion models")
+    active_names = tuple(str(name) for name in active_dofs)
+    active_indices = tuple(DOF_INDEX[name] for name in active_names)
+    coord = (
+        _normalize_coordinate(np.arange(int(n_views), dtype=np.float64))
+        if scan_coordinate is None
+        else _normalize_coordinate(np.asarray(scan_coordinate, dtype=np.float64))
+    )
+    if coord.shape != (int(n_views),):
+        raise ValueError(
+            f"scan_coordinate must have shape ({int(n_views)},), got {coord.shape}"
+        )
+
+    basis_np = build_pose_basis(
+        name,
+        n_views=int(n_views),
+        scan_coordinate=coord,
+        knot_spacing=int(knot_spacing),
+        degree=int(degree),
+    )
+    basis = jnp.asarray(basis_np, dtype=jnp.float32)
+    basis_pinv = jnp.asarray(np.linalg.pinv(basis_np).astype(np.float32), dtype=jnp.float32)
+    return PoseMotionModel(
+        name=name,
+        basis=basis,
+        basis_pinv=basis_pinv,
+        active_indices=active_indices,
+        active_names=active_names,
+        frozen_params5=jnp.asarray(frozen_params5, dtype=jnp.float32),
+    )
+
+
+def build_pose_basis(
+    pose_model: PoseModelName,
+    *,
+    n_views: int,
+    scan_coordinate: np.ndarray,
+    knot_spacing: int,
+    degree: int,
+) -> np.ndarray:
+    """Return a basis matrix with shape (n_views, n_basis)."""
+    if pose_model == "per_view":
+        return np.eye(int(n_views), dtype=np.float32)
+    if pose_model == "polynomial":
+        if int(degree) < 0:
+            raise ValueError("degree must be >= 0 for polynomial pose_model")
+        n_basis = min(int(degree) + 1, int(n_views))
+        cols = [np.power(scan_coordinate, p) for p in range(n_basis)]
+        return np.stack(cols, axis=1).astype(np.float32)
+    if pose_model == "spline":
+        if int(knot_spacing) < 1:
+            raise ValueError("knot_spacing must be >= 1 for spline pose_model")
+        if int(degree) not in (1, 2, 3):
+            raise ValueError("degree must be one of 1, 2, or 3 for spline pose_model")
+        return _spline_interpolation_basis(
+            scan_coordinate,
+            knot_spacing=int(knot_spacing),
+            degree=int(degree),
+        )
+    raise ValueError(f"Unsupported pose_model: {pose_model!r}")
+
+
+def fit_motion_coefficients(model: PoseMotionModel, params5: jnp.ndarray) -> jnp.ndarray:
+    """Fit active-DOF model coefficients from an expanded per-view array."""
+    active_params = params5[:, jnp.asarray(model.active_indices, dtype=jnp.int32)]
+    return model.basis_pinv @ active_params
+
+
+def expand_motion_coefficients(model: PoseMotionModel, coeffs: jnp.ndarray) -> jnp.ndarray:
+    """Expand coefficient variables back to a per-view (n_views, 5) array."""
+    active_params = model.basis @ coeffs
+    params5 = jnp.asarray(model.frozen_params5, dtype=jnp.float32)
+    active_indices = jnp.asarray(model.active_indices, dtype=jnp.int32)
+    return params5.at[:, active_indices].set(active_params)
+
+
+def _normalize_pose_model(raw: str) -> PoseModelName:
+    value = str(raw).strip().lower()
+    if value in {"per-view", "perview"}:
+        value = "per_view"
+    if value not in {"per_view", "polynomial", "spline"}:
+        raise ValueError(
+            "pose_model must be one of 'per_view', 'polynomial', or 'spline'"
+        )
+    return value  # type: ignore[return-value]
+
+
+def _normalize_coordinate(coord: np.ndarray) -> np.ndarray:
+    arr = np.asarray(coord, dtype=np.float64)
+    if arr.ndim != 1:
+        raise ValueError(f"scan coordinate must be one-dimensional, got {arr.shape}")
+    if arr.size == 1:
+        return np.zeros_like(arr, dtype=np.float64)
+    lo = float(np.min(arr))
+    hi = float(np.max(arr))
+    span = hi - lo
+    if span <= 0.0:
+        return np.linspace(-1.0, 1.0, arr.size, dtype=np.float64)
+    return (2.0 * ((arr - lo) / span) - 1.0).astype(np.float64)
+
+
+def _spline_interpolation_basis(
+    scan_coordinate: np.ndarray,
+    *,
+    knot_spacing: int,
+    degree: int,
+) -> np.ndarray:
+    n_views = int(scan_coordinate.shape[0])
+    if n_views == 1:
+        return np.ones((1, 1), dtype=np.float32)
+
+    knot_indices = list(range(0, n_views, int(knot_spacing)))
+    if knot_indices[-1] != n_views - 1:
+        knot_indices.append(n_views - 1)
+    knot_indices_np = np.asarray(knot_indices, dtype=np.int64)
+    knot_x = np.asarray(scan_coordinate[knot_indices_np], dtype=np.float64)
+    n_knots = int(knot_x.size)
+    if n_knots == 1:
+        return np.ones((n_views, 1), dtype=np.float32)
+
+    eff_degree = min(int(degree), n_knots - 1)
+    if eff_degree <= 1:
+        return _linear_interpolation_basis(scan_coordinate, knot_x)
+
+    try:
+        from scipy.interpolate import make_interp_spline
+    except Exception:
+        return _linear_interpolation_basis(scan_coordinate, knot_x)
+
+    cols = []
+    for i in range(n_knots):
+        values = np.zeros((n_knots,), dtype=np.float64)
+        values[i] = 1.0
+        try:
+            spline = make_interp_spline(knot_x, values, k=eff_degree)
+            col = np.asarray(spline(scan_coordinate), dtype=np.float64)
+        except Exception:
+            return _linear_interpolation_basis(scan_coordinate, knot_x)
+        cols.append(col)
+    return np.stack(cols, axis=1).astype(np.float32)
+
+
+def _linear_interpolation_basis(scan_coordinate: np.ndarray, knot_x: np.ndarray) -> np.ndarray:
+    cols = []
+    for i in range(int(knot_x.size)):
+        values = np.zeros((int(knot_x.size),), dtype=np.float64)
+        values[i] = 1.0
+        cols.append(np.interp(scan_coordinate, knot_x, values))
+    return np.stack(cols, axis=1).astype(np.float32)
+
+
+__all__ = [
+    "PoseMotionModel",
+    "PoseModelName",
+    "build_pose_basis",
+    "build_pose_motion_model",
+    "expand_motion_coefficients",
+    "fit_motion_coefficients",
+    "scan_coordinate_from_geometry",
+]

--- a/src/tomojax/align/pipeline.py
+++ b/src/tomojax/align/pipeline.py
@@ -22,12 +22,25 @@ from ..core.validation import (
 from ..recon.fista_tv import FistaConfig, fista_tv
 from ..utils.logging import progress_iter, format_duration
 from .parametrizations import se3_from_5d
-from .dofs import DofBounds, active_dof_mask, bounds_vectors, normalize_bounds, normalize_dofs
+from .dofs import (
+    DofBounds,
+    active_dof_mask,
+    active_dofs,
+    bounds_vectors,
+    normalize_bounds,
+    normalize_dofs,
+)
 from .losses import (
     L2OtsuLossSpec,
     AlignmentLossSpec,
     build_loss_adapter,
     loss_is_within_relative_tolerance,
+)
+from .motion_models import (
+    build_pose_motion_model,
+    expand_motion_coefficients,
+    fit_motion_coefficients,
+    scan_coordinate_from_geometry,
 )
 from ..utils.fov import cylindrical_mask_xy
 
@@ -45,6 +58,11 @@ class AlignInfo(TypedDict):
     stopped_by_observer: bool
     observer_action: ObserverAction
     wall_time_total: float
+    pose_model: str
+    pose_model_variables: int
+    per_view_variables: int
+    pose_model_basis_shape: list[int]
+    active_dofs: list[str]
 
 
 class AlignMultiresInfo(TypedDict):
@@ -54,6 +72,11 @@ class AlignMultiresInfo(TypedDict):
     observer_action: ObserverAction
     total_outer_iters: int
     wall_time_total: float
+    pose_model: str
+    pose_model_variables: int | None
+    per_view_variables: int | None
+    pose_model_basis_shape: list[int] | None
+    active_dofs: list[str]
 
 
 class MultiresLevel(TypedDict):
@@ -262,6 +285,9 @@ class AlignConfig:
     optimise_dofs: tuple[str, ...] | None = None
     freeze_dofs: tuple[str, ...] = field(default_factory=tuple)
     bounds: DofBounds | str | Mapping[str, object] = field(default_factory=tuple)
+    pose_model: Literal["per_view", "polynomial", "spline"] = "per_view"
+    knot_spacing: int = 8
+    degree: int = 3
     seed_translations: bool = False
     # Volume masking before forward projection (modeling for ROI/truncation)
     # Options: "off" (default), "cyl" (cylindrical mask in x–y broadcast along z)
@@ -290,6 +316,19 @@ class AlignConfig:
         self.freeze_dofs = normalize_dofs(self.freeze_dofs, option_name="freeze_dofs")
         active_dof_mask(optimise_dofs=self.optimise_dofs, freeze_dofs=self.freeze_dofs)
         self.bounds = normalize_bounds(self.bounds, option_name="bounds")
+        pose_model = str(self.pose_model).strip().lower().replace("-", "_")
+        self.pose_model = pose_model  # type: ignore[assignment]
+        if self.pose_model not in {"per_view", "polynomial", "spline"}:
+            raise ValueError(
+                "pose_model must be one of 'per_view', 'polynomial', or 'spline'"
+            )
+        if self.pose_model == "polynomial" and int(self.degree) < 0:
+            raise ValueError("degree must be >= 0 for polynomial pose_model")
+        if self.pose_model == "spline":
+            if int(self.knot_spacing) < 1:
+                raise ValueError("knot_spacing must be >= 1 for spline pose_model")
+            if int(self.degree) not in (1, 2, 3):
+                raise ValueError("degree must be one of 1, 2, or 3 for spline pose_model")
 
 
 def align(
@@ -341,6 +380,10 @@ def align(
         active_dof_mask(optimise_dofs=cfg.optimise_dofs, freeze_dofs=cfg.freeze_dofs),
         dtype=bool,
     )
+    active_names = active_dofs(
+        optimise_dofs=cfg.optimise_dofs,
+        freeze_dofs=cfg.freeze_dofs,
+    )
     active_mask = active_mask_bool.astype(jnp.float32)
     bounds_lower, bounds_upper = bounds_vectors(cfg.bounds)
 
@@ -349,6 +392,33 @@ def align(
         return jnp.where(active_mask_bool, clipped, frozen_params5)
 
     params5 = _apply_param_constraints(params5)
+
+    scan_coordinate = scan_coordinate_from_geometry(geometry, n_views)
+    motion_model = build_pose_motion_model(
+        pose_model=str(cfg.pose_model),
+        n_views=n_views,
+        active_dofs=active_names,
+        frozen_params5=frozen_params5,
+        scan_coordinate=scan_coordinate,
+        knot_spacing=int(cfg.knot_spacing),
+        degree=int(cfg.degree),
+    )
+    use_smooth_pose_model = motion_model.name != "per_view"
+    motion_coeffs = None
+    active_coeff_indices = jnp.asarray(motion_model.active_indices, dtype=jnp.int32)
+
+    def _coeffs_to_constrained_params(coeffs: jnp.ndarray) -> jnp.ndarray:
+        return _apply_param_constraints(expand_motion_coefficients(motion_model, coeffs))
+
+    def _project_params_to_smooth(candidate: jnp.ndarray) -> jnp.ndarray:
+        constrained = _apply_param_constraints(candidate)
+        coeffs = fit_motion_coefficients(motion_model, constrained)
+        return _coeffs_to_constrained_params(coeffs)
+
+    if use_smooth_pose_model:
+        motion_coeffs = fit_motion_coefficients(motion_model, params5)
+        params5 = _coeffs_to_constrained_params(motion_coeffs)
+        motion_coeffs = fit_motion_coefficients(motion_model, params5)
 
     loss_hist = []
     stopped_by_observer = False
@@ -486,6 +556,15 @@ def align(
 
     # Value function for whole batch (forward only) kept for logging and line search
     align_loss_jit = jax.jit(align_loss)
+
+    if use_smooth_pose_model:
+
+        def motion_align_loss(coeffs, vol):
+            return align_loss(_coeffs_to_constrained_params(coeffs), vol)
+
+        motion_loss_and_grad = jax.jit(jax.value_and_grad(motion_align_loss))
+    else:
+        motion_loss_and_grad = None
 
     # Memory-safe gradient over fixed-size chunks.
     if has_loss_mask:
@@ -984,11 +1063,14 @@ def align(
         if step_kind == "gn":
             params5_prev = params5
             dp_all = _gn_update_all(params5_prev, x) * active_mask
+            constrain_candidate = (
+                _project_params_to_smooth if use_smooth_pose_model else _apply_param_constraints
+            )
             if cfg.gn_accept_only_improving and (loss_before is not None):
                 smooth_candidate = None
                 if int(params5.shape[0]) >= 3:
                     smooth_candidate = lambda candidate, weights: _smooth_gn_candidate(
-                        _apply_param_constraints(candidate),
+                        constrain_candidate(candidate),
                         smoothness_gram,
                         weights,
                     )
@@ -1004,16 +1086,16 @@ def align(
                         )
                     ),
                     gn_accept_tol=cfg.gn_accept_tol,
-                    constrain_candidate=_apply_param_constraints,
+                    constrain_candidate=constrain_candidate,
                     smooth_candidate=smooth_candidate,
                     light_smoothness_weights_sq=light_smoothness_weights_sq,
                     medium_smoothness_weights_sq=medium_smoothness_weights_sq,
                     smoothness_weights_sq=smoothness_weights_sq,
                     trans_only_smoothness_weights_sq=trans_only_smoothness_weights_sq,
                 )
-                params5 = _apply_param_constraints(params5)
+                params5 = constrain_candidate(params5)
             else:
-                params5 = _apply_param_constraints(params5_prev + dp_all)
+                params5 = constrain_candidate(params5_prev + dp_all)
                 candidate_loss = _evaluate_align_loss(
                     lambda: align_loss_jit(params5, x),
                     fallback=math.inf,
@@ -1024,6 +1106,9 @@ def align(
                 else:
                     params5 = params5_prev
                     loss_after = loss_before
+            if use_smooth_pose_model:
+                motion_coeffs = fit_motion_coefficients(motion_model, params5)
+                params5 = _coeffs_to_constrained_params(motion_coeffs)
             # Log step stats
             try:
                 stat["rot_mean"] = float(jnp.mean(jnp.abs(dp_all[:, :3])))
@@ -1035,34 +1120,69 @@ def align(
             scales = jnp.array(
                 [cfg.lr_rot, cfg.lr_rot, cfg.lr_rot, cfg.lr_trans, cfg.lr_trans], dtype=jnp.float32
             )
-            # Keep a copy for line search; donated arg may be reused internally
-            p5_in = params5
-            _, g_params = loss_and_grad_manual(params5, x)
-            g_params = g_params * active_mask
-            rms = jnp.sqrt(jnp.mean(jnp.square(g_params), axis=0)) + 1e-6
-            eff_scales = scales / rms
-            # Simple 2-point line search on step factor to improve single-iter progress
-            best_params = _apply_param_constraints(p5_in - g_params * eff_scales)
-            best_loss = _evaluate_align_loss(
-                lambda: align_loss_jit(best_params, x),
-                fallback=math.inf,
-                context="Treating GD base candidate as rejected during alignment loss evaluation",
-            )
-            cand_params = _apply_param_constraints(p5_in - 2.0 * g_params * eff_scales)
-            cand_loss = _evaluate_align_loss(
-                lambda: align_loss_jit(cand_params, x),
-                fallback=math.inf,
-                context="Treating GD doubled-step candidate as rejected during alignment loss evaluation",
-            )
-            best_loss_f = float(best_loss) if best_loss is not None else math.inf
-            cand_loss_f = float(cand_loss) if cand_loss is not None else math.inf
-            if not math.isfinite(best_loss_f) and not math.isfinite(cand_loss_f):
-                params5 = p5_in
-                loss_after = loss_before
+            if use_smooth_pose_model:
+                if motion_coeffs is None or motion_loss_and_grad is None:
+                    raise RuntimeError("smooth pose model coefficients were not initialized")
+                coeffs_in = motion_coeffs
+                _, g_coeffs = motion_loss_and_grad(coeffs_in, x)
+                active_scales = scales[active_coeff_indices]
+                rms_active = jnp.sqrt(jnp.mean(jnp.square(g_coeffs), axis=0)) + 1e-6
+                eff_scales = active_scales / rms_active
+                best_coeffs = coeffs_in - g_coeffs * eff_scales[None, :]
+                best_params = _coeffs_to_constrained_params(best_coeffs)
+                best_loss = _evaluate_align_loss(
+                    lambda: align_loss_jit(best_params, x),
+                    fallback=math.inf,
+                    context="Treating GD base candidate as rejected during alignment loss evaluation",
+                )
+                cand_coeffs = coeffs_in - 2.0 * g_coeffs * eff_scales[None, :]
+                cand_params = _coeffs_to_constrained_params(cand_coeffs)
+                cand_loss = _evaluate_align_loss(
+                    lambda: align_loss_jit(cand_params, x),
+                    fallback=math.inf,
+                    context="Treating GD doubled-step candidate as rejected during alignment loss evaluation",
+                )
+                best_loss_f = float(best_loss) if best_loss is not None else math.inf
+                cand_loss_f = float(cand_loss) if cand_loss is not None else math.inf
+                if not math.isfinite(best_loss_f) and not math.isfinite(cand_loss_f):
+                    params5 = _coeffs_to_constrained_params(coeffs_in)
+                    loss_after = loss_before
+                else:
+                    params5 = cand_params if cand_loss_f < best_loss_f else best_params
+                    chosen_loss = min(best_loss_f, cand_loss_f)
+                    loss_after = float(chosen_loss) if math.isfinite(chosen_loss) else loss_before
+                motion_coeffs = fit_motion_coefficients(motion_model, params5)
+                params5 = _coeffs_to_constrained_params(motion_coeffs)
+                rms = jnp.zeros((5,), dtype=jnp.float32).at[active_coeff_indices].set(rms_active)
             else:
-                params5 = cand_params if cand_loss_f < best_loss_f else best_params
-                chosen_loss = min(best_loss_f, cand_loss_f)
-                loss_after = float(chosen_loss) if math.isfinite(chosen_loss) else loss_before
+                # Keep a copy for line search; donated arg may be reused internally
+                p5_in = params5
+                _, g_params = loss_and_grad_manual(params5, x)
+                g_params = g_params * active_mask
+                rms = jnp.sqrt(jnp.mean(jnp.square(g_params), axis=0)) + 1e-6
+                eff_scales = scales / rms
+                # Simple 2-point line search on step factor to improve single-iter progress
+                best_params = _apply_param_constraints(p5_in - g_params * eff_scales)
+                best_loss = _evaluate_align_loss(
+                    lambda: align_loss_jit(best_params, x),
+                    fallback=math.inf,
+                    context="Treating GD base candidate as rejected during alignment loss evaluation",
+                )
+                cand_params = _apply_param_constraints(p5_in - 2.0 * g_params * eff_scales)
+                cand_loss = _evaluate_align_loss(
+                    lambda: align_loss_jit(cand_params, x),
+                    fallback=math.inf,
+                    context="Treating GD doubled-step candidate as rejected during alignment loss evaluation",
+                )
+                best_loss_f = float(best_loss) if best_loss is not None else math.inf
+                cand_loss_f = float(cand_loss) if cand_loss is not None else math.inf
+                if not math.isfinite(best_loss_f) and not math.isfinite(cand_loss_f):
+                    params5 = p5_in
+                    loss_after = loss_before
+                else:
+                    params5 = cand_params if cand_loss_f < best_loss_f else best_params
+                    chosen_loss = min(best_loss_f, cand_loss_f)
+                    loss_after = float(chosen_loss) if math.isfinite(chosen_loss) else loss_before
             try:
                 stat["rot_rms"] = float(jnp.mean(rms[:3]))
                 stat["trans_rms"] = float(jnp.mean(rms[3:]))
@@ -1189,6 +1309,14 @@ def align(
         "stopped_by_observer": stopped_by_observer,
         "observer_action": observer_action,
         "wall_time_total": float(wall_total),
+        "pose_model": motion_model.name,
+        "pose_model_variables": int(motion_model.variable_count),
+        "per_view_variables": int(motion_model.per_view_variable_count),
+        "pose_model_basis_shape": [
+            int(motion_model.basis.shape[0]),
+            int(motion_model.basis.shape[1]),
+        ],
+        "active_dofs": list(motion_model.active_names),
     }
     return x, params5, info
 
@@ -1253,6 +1381,9 @@ def align_multires(
     global_outer_idx = 0
     global_elapsed_offset = 0.0
     executed_outer_iters = 0
+    final_pose_model_variables: int | None = None
+    final_per_view_variables: int | None = None
+    final_pose_model_basis_shape: list[int] | None = None
 
     for li, lvl in enumerate(levels):
         g = lvl["grid"]
@@ -1357,6 +1488,9 @@ def align_multires(
         )
         loss_hist.extend(info.get("loss", []))
         executed_outer_iters += len(info.get("outer_stats", []))
+        final_pose_model_variables = int(info["pose_model_variables"])
+        final_per_view_variables = int(info["per_view_variables"])
+        final_pose_model_basis_shape = list(info["pose_model_basis_shape"])
         x_init = x_lvl
         prev_factor = lvl["factor"]
         try:
@@ -1389,5 +1523,15 @@ def align_multires(
             "observer_action": final_observer_action,
             "total_outer_iters": int(executed_outer_iters),
             "wall_time_total": float(global_elapsed_offset),
+            "pose_model": str(cfg.pose_model),
+            "pose_model_variables": final_pose_model_variables,
+            "per_view_variables": final_per_view_variables,
+            "pose_model_basis_shape": final_pose_model_basis_shape,
+            "active_dofs": list(
+                active_dofs(
+                    optimise_dofs=cfg.optimise_dofs,
+                    freeze_dofs=cfg.freeze_dofs,
+                )
+            ),
         },
     )

--- a/src/tomojax/align/pipeline.py
+++ b/src/tomojax/align/pipeline.py
@@ -22,7 +22,13 @@ from ..core.validation import (
 from ..recon.fista_tv import FistaConfig, fista_tv
 from ..utils.logging import progress_iter, format_duration
 from .parametrizations import se3_from_5d
-from .losses import L2OtsuLossSpec, AlignmentLossSpec, build_loss_adapter, loss_is_within_relative_tolerance
+from .dofs import active_dof_mask, normalize_dofs
+from .losses import (
+    L2OtsuLossSpec,
+    AlignmentLossSpec,
+    build_loss_adapter,
+    loss_is_within_relative_tolerance,
+)
 from ..utils.fov import cylindrical_mask_xy
 
 
@@ -247,6 +253,8 @@ class AlignConfig:
     gn_damping: float = 1e-6
     w_rot: float = 0.0
     w_trans: float = 0.0
+    optimise_dofs: tuple[str, ...] | None = None
+    freeze_dofs: tuple[str, ...] = field(default_factory=tuple)
     seed_translations: bool = False
     # Volume masking before forward projection (modeling for ROI/truncation)
     # Options: "off" (default), "cyl" (cylindrical mask in x–y broadcast along z)
@@ -265,6 +273,15 @@ class AlignConfig:
     gn_accept_tol: float = 0.0  # allow tiny increases if >0 (as fraction of before)
     # Data term / similarity
     loss: AlignmentLossSpec = field(default_factory=L2OtsuLossSpec)
+
+    def __post_init__(self) -> None:
+        if self.optimise_dofs is not None:
+            self.optimise_dofs = normalize_dofs(
+                self.optimise_dofs,
+                option_name="optimise_dofs",
+            )
+        self.freeze_dofs = normalize_dofs(self.freeze_dofs, option_name="freeze_dofs")
+        active_dof_mask(optimise_dofs=self.optimise_dofs, freeze_dofs=self.freeze_dofs)
 
 
 def align(
@@ -311,6 +328,15 @@ def align(
         if init_params5 is not None
         else jnp.zeros((n_views, 5), dtype=jnp.float32)
     )
+    frozen_params5 = params5
+    active_mask_bool = jnp.asarray(
+        active_dof_mask(optimise_dofs=cfg.optimise_dofs, freeze_dofs=cfg.freeze_dofs),
+        dtype=bool,
+    )
+    active_mask = active_mask_bool.astype(jnp.float32)
+
+    def _restore_frozen(candidate: jnp.ndarray) -> jnp.ndarray:
+        return jnp.where(active_mask_bool, candidate, frozen_params5)
 
     loss_hist = []
     stopped_by_observer = False
@@ -340,7 +366,7 @@ def align(
     # Static smoothness weights to avoid rebuilding inside jitted loss
     W_weights = jnp.array(
         [cfg.w_rot, cfg.w_rot, cfg.w_rot, cfg.w_trans, cfg.w_trans], dtype=jnp.float32
-    )
+    ) * active_mask
     smoothness_gram = _second_difference_gram(n_views)
     smoothness_weights_sq = W_weights * W_weights
     medium_smoothness_weights_sq = smoothness_weights_sq * jnp.float32(0.4)
@@ -517,7 +543,7 @@ def align(
                 w = jnp.array(
                     [cfg.w_rot, cfg.w_rot, cfg.w_rot, cfg.w_trans, cfg.w_trans],
                     jnp.float32,
-                )
+                ) * active_mask
                 total = total + jnp.sum((d2 * w) ** 2)
                 ww = (w**2) * 2.0
                 g = g.at[1:-1].add(-2.0 * d2 * ww)
@@ -587,7 +613,7 @@ def align(
                 w = jnp.array(
                     [cfg.w_rot, cfg.w_rot, cfg.w_rot, cfg.w_trans, cfg.w_trans],
                     jnp.float32,
-                )
+                ) * active_mask
                 total = total + jnp.sum((d2 * w) ** 2)
                 ww = (w**2) * 2.0
                 g = g.at[1:-1].add(-2.0 * d2 * ww)
@@ -629,8 +655,13 @@ def align(
         cols = jax.vmap(jvp_col)(eye5)
         H = cols @ cols.T
         lam = jnp.float32(cfg.gn_damping)
-        dp = jnp.linalg.solve(H + lam * jnp.eye(5, dtype=H.dtype), -g)
-        return dp
+        active = active_mask.astype(H.dtype)
+        inactive = jnp.float32(1.0) - active
+        H_active = H * active[:, None] * active[None, :]
+        system = H_active + lam * jnp.diag(active) + jnp.diag(inactive)
+        rhs = -g * active
+        dp = jnp.linalg.solve(system, rhs)
+        return dp * active
 
     _gn_update_batch = jax.jit(jax.vmap(_gn_update_one, in_axes=(0, 0, 0, None, 0)))
 
@@ -940,12 +971,12 @@ def align(
         loss_after = None
         if step_kind == "gn":
             params5_prev = params5
-            dp_all = _gn_update_all(params5_prev, x)
+            dp_all = _gn_update_all(params5_prev, x) * active_mask
             if cfg.gn_accept_only_improving and (loss_before is not None):
                 smooth_candidate = None
                 if int(params5.shape[0]) >= 3:
                     smooth_candidate = lambda candidate, weights: _smooth_gn_candidate(
-                        candidate,
+                        _restore_frozen(candidate),
                         smoothness_gram,
                         weights,
                     )
@@ -967,8 +998,9 @@ def align(
                     smoothness_weights_sq=smoothness_weights_sq,
                     trans_only_smoothness_weights_sq=trans_only_smoothness_weights_sq,
                 )
+                params5 = _restore_frozen(params5)
             else:
-                params5 = params5_prev + dp_all
+                params5 = _restore_frozen(params5_prev + dp_all)
                 candidate_loss = _evaluate_align_loss(
                     lambda: align_loss_jit(params5, x),
                     fallback=math.inf,
@@ -993,16 +1025,17 @@ def align(
             # Keep a copy for line search; donated arg may be reused internally
             p5_in = params5
             _, g_params = loss_and_grad_manual(params5, x)
+            g_params = g_params * active_mask
             rms = jnp.sqrt(jnp.mean(jnp.square(g_params), axis=0)) + 1e-6
             eff_scales = scales / rms
             # Simple 2-point line search on step factor to improve single-iter progress
-            best_params = p5_in - g_params * eff_scales
+            best_params = _restore_frozen(p5_in - g_params * eff_scales)
             best_loss = _evaluate_align_loss(
                 lambda: align_loss_jit(best_params, x),
                 fallback=math.inf,
                 context="Treating GD base candidate as rejected during alignment loss evaluation",
             )
-            cand_params = p5_in - 2.0 * g_params * eff_scales
+            cand_params = _restore_frozen(p5_in - 2.0 * g_params * eff_scales)
             cand_loss = _evaluate_align_loss(
                 lambda: align_loss_jit(cand_params, x),
                 fallback=math.inf,
@@ -1165,6 +1198,10 @@ def align_multires(
 
     if cfg is None:
         cfg = AlignConfig()
+    active_mask_tuple = active_dof_mask(
+        optimise_dofs=cfg.optimise_dofs,
+        freeze_dofs=cfg.freeze_dofs,
+    )
 
     validate_grid(grid, "align_multires grid")
     validate_projection_stack(
@@ -1258,9 +1295,16 @@ def align_multires(
             # Convert pixel shifts to world units using detector spacing
             dx = shifts[:, 0] * jnp.float32(d.du)
             dz = shifts[:, 1] * jnp.float32(d.dv)
-            params0 = jnp.zeros((y.shape[0], 5), dtype=jnp.float32)
-            params0 = params0.at[:, 3].set(dx)
-            params0 = params0.at[:, 4].set(dz)
+            seed_params = (
+                jnp.zeros((y.shape[0], 5), dtype=jnp.float32)
+                if params0 is None
+                else jnp.asarray(params0, dtype=jnp.float32)
+            )
+            if active_mask_tuple[3]:
+                seed_params = seed_params.at[:, 3].set(dx)
+            if active_mask_tuple[4]:
+                seed_params = seed_params.at[:, 4].set(dz)
+            params0 = seed_params
 
         # Run alignment at this level
         # Re-estimate L at each level using a fresh (streamed) power-method for stability

--- a/src/tomojax/align/pipeline.py
+++ b/src/tomojax/align/pipeline.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field, replace
 import logging
 import math
 import time
-from typing import Callable, Iterable, Literal, TypedDict
+from typing import Callable, Iterable, Literal, Mapping, TypedDict
 
 import jax
 import jax.numpy as jnp
@@ -22,7 +22,7 @@ from ..core.validation import (
 from ..recon.fista_tv import FistaConfig, fista_tv
 from ..utils.logging import progress_iter, format_duration
 from .parametrizations import se3_from_5d
-from .dofs import active_dof_mask, normalize_dofs
+from .dofs import DofBounds, active_dof_mask, bounds_vectors, normalize_bounds, normalize_dofs
 from .losses import (
     L2OtsuLossSpec,
     AlignmentLossSpec,
@@ -131,6 +131,7 @@ def _select_gn_candidate(
     loss_before: float,
     eval_loss: Callable[[jnp.ndarray], float],
     gn_accept_tol: float,
+    constrain_candidate: Callable[[jnp.ndarray], jnp.ndarray] | None = None,
     smooth_candidate: Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray] | None = None,
     light_smoothness_weights_sq: jnp.ndarray | None = None,
     medium_smoothness_weights_sq: jnp.ndarray | None = None,
@@ -147,12 +148,17 @@ def _select_gn_candidate(
             gn_accept_tol,
         )
 
-    raw_params = params5_prev + dp_all
+    def _constrain(candidate: jnp.ndarray) -> jnp.ndarray:
+        if constrain_candidate is None:
+            return candidate
+        return constrain_candidate(candidate)
+
+    raw_params = _constrain(params5_prev + dp_all)
     raw_loss = eval_loss(raw_params)
     if _accepts(raw_loss):
         return raw_params, raw_loss
 
-    half_params = params5_prev + jnp.float32(0.5) * dp_all
+    half_params = _constrain(params5_prev + jnp.float32(0.5) * dp_all)
     half_loss = eval_loss(half_params)
     if _accepts(half_loss):
         return half_params, half_loss
@@ -182,7 +188,7 @@ def _select_gn_candidate(
     best_loss = float("inf")
     accepted = False
     for weights in smooth_weights:
-        candidate_params = smooth_candidate(base_params, weights)
+        candidate_params = _constrain(smooth_candidate(base_params, weights))
         candidate_loss = eval_loss(candidate_params)
         if _accepts(candidate_loss, best_loss):
             best_params = candidate_params
@@ -255,6 +261,7 @@ class AlignConfig:
     w_trans: float = 0.0
     optimise_dofs: tuple[str, ...] | None = None
     freeze_dofs: tuple[str, ...] = field(default_factory=tuple)
+    bounds: DofBounds | str | Mapping[str, object] = field(default_factory=tuple)
     seed_translations: bool = False
     # Volume masking before forward projection (modeling for ROI/truncation)
     # Options: "off" (default), "cyl" (cylindrical mask in x–y broadcast along z)
@@ -282,6 +289,7 @@ class AlignConfig:
             )
         self.freeze_dofs = normalize_dofs(self.freeze_dofs, option_name="freeze_dofs")
         active_dof_mask(optimise_dofs=self.optimise_dofs, freeze_dofs=self.freeze_dofs)
+        self.bounds = normalize_bounds(self.bounds, option_name="bounds")
 
 
 def align(
@@ -334,9 +342,13 @@ def align(
         dtype=bool,
     )
     active_mask = active_mask_bool.astype(jnp.float32)
+    bounds_lower, bounds_upper = bounds_vectors(cfg.bounds)
 
-    def _restore_frozen(candidate: jnp.ndarray) -> jnp.ndarray:
-        return jnp.where(active_mask_bool, candidate, frozen_params5)
+    def _apply_param_constraints(candidate: jnp.ndarray) -> jnp.ndarray:
+        clipped = jnp.clip(candidate, bounds_lower, bounds_upper)
+        return jnp.where(active_mask_bool, clipped, frozen_params5)
+
+    params5 = _apply_param_constraints(params5)
 
     loss_hist = []
     stopped_by_observer = False
@@ -976,7 +988,7 @@ def align(
                 smooth_candidate = None
                 if int(params5.shape[0]) >= 3:
                     smooth_candidate = lambda candidate, weights: _smooth_gn_candidate(
-                        _restore_frozen(candidate),
+                        _apply_param_constraints(candidate),
                         smoothness_gram,
                         weights,
                     )
@@ -992,15 +1004,16 @@ def align(
                         )
                     ),
                     gn_accept_tol=cfg.gn_accept_tol,
+                    constrain_candidate=_apply_param_constraints,
                     smooth_candidate=smooth_candidate,
                     light_smoothness_weights_sq=light_smoothness_weights_sq,
                     medium_smoothness_weights_sq=medium_smoothness_weights_sq,
                     smoothness_weights_sq=smoothness_weights_sq,
                     trans_only_smoothness_weights_sq=trans_only_smoothness_weights_sq,
                 )
-                params5 = _restore_frozen(params5)
+                params5 = _apply_param_constraints(params5)
             else:
-                params5 = _restore_frozen(params5_prev + dp_all)
+                params5 = _apply_param_constraints(params5_prev + dp_all)
                 candidate_loss = _evaluate_align_loss(
                     lambda: align_loss_jit(params5, x),
                     fallback=math.inf,
@@ -1029,13 +1042,13 @@ def align(
             rms = jnp.sqrt(jnp.mean(jnp.square(g_params), axis=0)) + 1e-6
             eff_scales = scales / rms
             # Simple 2-point line search on step factor to improve single-iter progress
-            best_params = _restore_frozen(p5_in - g_params * eff_scales)
+            best_params = _apply_param_constraints(p5_in - g_params * eff_scales)
             best_loss = _evaluate_align_loss(
                 lambda: align_loss_jit(best_params, x),
                 fallback=math.inf,
                 context="Treating GD base candidate as rejected during alignment loss evaluation",
             )
-            cand_params = _restore_frozen(p5_in - 2.0 * g_params * eff_scales)
+            cand_params = _apply_param_constraints(p5_in - 2.0 * g_params * eff_scales)
             cand_loss = _evaluate_align_loss(
                 lambda: align_loss_jit(cand_params, x),
                 fallback=math.inf,

--- a/src/tomojax/cli/align.py
+++ b/src/tomojax/cli/align.py
@@ -189,6 +189,27 @@ def _build_parser() -> argparse.ArgumentParser:
             "world units. Example: dx=-20:20,dz=-20:20,alpha=-0.05:0.05"
         ),
     )
+    p.add_argument(
+        "--pose-model",
+        choices=["per_view", "polynomial", "spline"],
+        default="per_view",
+        help=(
+            "Alignment pose parameterization: per_view optimizes one 5-DOF vector per "
+            "view; polynomial and spline optimize smooth low-dimensional trajectories"
+        ),
+    )
+    p.add_argument(
+        "--knot-spacing",
+        type=int,
+        default=8,
+        help="View spacing between spline knots when --pose-model spline is used",
+    )
+    p.add_argument(
+        "--degree",
+        type=int,
+        default=3,
+        help="Polynomial degree or spline degree for smooth pose models",
+    )
     p.add_argument("--w-rot", type=float, default=1e-3, help="Smoothness weight for rotations")
     p.add_argument("--w-trans", type=float, default=1e-3, help="Smoothness weight for translations")
     p.add_argument(
@@ -410,6 +431,9 @@ def main() -> None:
         optimise_dofs=optimise_dofs,
         freeze_dofs=freeze_dofs,
         bounds=args.bounds,
+        pose_model=str(args.pose_model),
+        knot_spacing=int(args.knot_spacing),
+        degree=int(args.degree),
         loss=loss_spec,
         seed_translations=bool(args.seed_translations),
         log_summary=bool(args.log_summary),

--- a/src/tomojax/cli/align.py
+++ b/src/tomojax/cli/align.py
@@ -10,6 +10,7 @@ import sys
 
 from ..data.geometry_meta import build_geometry_from_meta
 from ..data.io_hdf5 import NXTomoMetadata, load_nxtomo, save_nxtomo
+from ..align.dofs import active_dof_mask, normalize_dofs
 from ..align.losses import parse_loss_spec
 from ..align.params_export import save_alignment_params_csv, save_alignment_params_json
 from ..core.geometry import Grid, Detector
@@ -96,6 +97,23 @@ def _resolve_recon_grid_and_mask(
     return recon_grid, apply_cyl_mask
 
 
+def _parse_dof_args(
+    args: argparse.Namespace,
+    parser: argparse.ArgumentParser,
+) -> tuple[tuple[str, ...] | None, tuple[str, ...]]:
+    try:
+        optimise_dofs = (
+            None
+            if args.optimise_dofs is None
+            else normalize_dofs(args.optimise_dofs, option_name="--optimise-dofs")
+        )
+        freeze_dofs = normalize_dofs(args.freeze_dofs, option_name="--freeze-dofs")
+        active_dof_mask(optimise_dofs=optimise_dofs, freeze_dofs=freeze_dofs)
+    except ValueError as exc:
+        parser.error(str(exc))
+    return optimise_dofs, freeze_dofs
+
+
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description="Joint reconstruction + alignment on dataset (.nxs)")
     p.add_argument("--config", help="Load command defaults from a TOML config file")
@@ -139,6 +157,20 @@ def _build_parser() -> argparse.ArgumentParser:
         type=float,
         default=1e-3,
         help="Levenberg-Marquardt damping for GN",
+    )
+    p.add_argument(
+        "--optimise-dofs",
+        nargs="+",
+        default=None,
+        metavar="DOF[,DOF]",
+        help="Named alignment DOFs to optimise: alpha,beta,phi,dx,dz. Example: dx,dz",
+    )
+    p.add_argument(
+        "--freeze-dofs",
+        nargs="+",
+        default=None,
+        metavar="DOF[,DOF]",
+        help="Named alignment DOFs to keep fixed at initial values. Example: phi",
     )
     p.add_argument("--w-rot", type=float, default=1e-3, help="Smoothness weight for rotations")
     p.add_argument("--w-trans", type=float, default=1e-3, help="Smoothness weight for translations")
@@ -321,6 +353,7 @@ def main() -> None:
         except ValueError:
             raise SystemExit(f"--loss-param value must be numeric: {kv}")
     loss_spec = parse_loss_spec(str(args.loss), loss_params if loss_params else None)
+    optimise_dofs, freeze_dofs = _parse_dof_args(args, p)
 
     meta = load_nxtomo(args.data)
     geometry_meta = meta.geometry_inputs()
@@ -357,6 +390,8 @@ def main() -> None:
         gn_damping=float(args.gn_damping),
         w_rot=float(args.w_rot),
         w_trans=float(args.w_trans),
+        optimise_dofs=optimise_dofs,
+        freeze_dofs=freeze_dofs,
         loss=loss_spec,
         seed_translations=bool(args.seed_translations),
         log_summary=bool(args.log_summary),

--- a/src/tomojax/cli/align.py
+++ b/src/tomojax/cli/align.py
@@ -10,7 +10,7 @@ import sys
 
 from ..data.geometry_meta import build_geometry_from_meta
 from ..data.io_hdf5 import NXTomoMetadata, load_nxtomo, save_nxtomo
-from ..align.dofs import active_dof_mask, normalize_dofs
+from ..align.dofs import DofBounds, active_dof_mask, normalize_bounds, normalize_dofs
 from ..align.losses import parse_loss_spec
 from ..align.params_export import save_alignment_params_csv, save_alignment_params_json
 from ..core.geometry import Grid, Detector
@@ -114,6 +114,13 @@ def _parse_dof_args(
     return optimise_dofs, freeze_dofs
 
 
+def _parse_bounds_arg(value: object) -> DofBounds:
+    try:
+        return normalize_bounds(value, option_name="--bounds")
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+
+
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description="Joint reconstruction + alignment on dataset (.nxs)")
     p.add_argument("--config", help="Load command defaults from a TOML config file")
@@ -171,6 +178,16 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         metavar="DOF[,DOF]",
         help="Named alignment DOFs to keep fixed at initial values. Example: phi",
+    )
+    p.add_argument(
+        "--bounds",
+        type=_parse_bounds_arg,
+        default=None,
+        metavar="DOF=LOWER:UPPER[,DOF=LOWER:UPPER]",
+        help=(
+            "Finite per-DOF parameter bounds. Rotations are radians; translations are "
+            "world units. Example: dx=-20:20,dz=-20:20,alpha=-0.05:0.05"
+        ),
     )
     p.add_argument("--w-rot", type=float, default=1e-3, help="Smoothness weight for rotations")
     p.add_argument("--w-trans", type=float, default=1e-3, help="Smoothness weight for translations")
@@ -392,6 +409,7 @@ def main() -> None:
         w_trans=float(args.w_trans),
         optimise_dofs=optimise_dofs,
         freeze_dofs=freeze_dofs,
+        bounds=args.bounds,
         loss=loss_spec,
         seed_translations=bool(args.seed_translations),
         log_summary=bool(args.log_summary),

--- a/tests/test_align_chunking.py
+++ b/tests/test_align_chunking.py
@@ -54,6 +54,8 @@ def _run_fixed_volume_alignment(
     opt_method: str,
     views_per_batch: int,
     loss_name: str,
+    init_params5=None,
+    **cfg_kwargs,
 ):
     _freeze_reconstruction(monkeypatch)
     grid, det, geom, vol, projs = make_misaligned_case(seed=7)
@@ -67,8 +69,17 @@ def _run_fixed_volume_alignment(
         opt_method=opt_method,
         loss=parse_loss_spec(loss_name),
         early_stop=False,
+        **cfg_kwargs,
     )
-    _, params5, info = align(geom, grid, det, projs, cfg=cfg, init_x=vol)
+    _, params5, info = align(
+        geom,
+        grid,
+        det,
+        projs,
+        cfg=cfg,
+        init_x=vol,
+        init_params5=init_params5,
+    )
     return np.asarray(params5), info
 
 
@@ -110,3 +121,53 @@ def test_align_gn_chunking_matches_streamed_reference(monkeypatch):
     assert info_chunked["loss"][-1] == pytest.approx(
         info_stream["loss"][-1], rel=1e-5, abs=1e-6
     )
+
+
+@pytest.mark.parametrize(
+    ("opt_method", "loss_name"),
+    [
+        ("gd", "l2_otsu"),
+        ("gn", "l2"),
+    ],
+)
+def test_align_freeze_phi_keeps_initial_values(monkeypatch, opt_method, loss_name):
+    _, _, _, _, projs = make_misaligned_case(seed=8)
+    init_params5 = np.zeros((projs.shape[0], 5), dtype=np.float32)
+    init_params5[:, 2] = np.linspace(-0.03, 0.03, projs.shape[0], dtype=np.float32)
+
+    params5, _ = _run_fixed_volume_alignment(
+        monkeypatch,
+        opt_method=opt_method,
+        views_per_batch=2,
+        loss_name=loss_name,
+        init_params5=jnp.asarray(init_params5),
+        freeze_dofs=("phi",),
+    )
+
+    np.testing.assert_array_equal(params5[:, 2], init_params5[:, 2])
+
+
+@pytest.mark.parametrize(
+    ("opt_method", "loss_name"),
+    [
+        ("gd", "l2_otsu"),
+        ("gn", "l2"),
+    ],
+)
+def test_align_optimise_only_dx_dz_keeps_rotations_initial(monkeypatch, opt_method, loss_name):
+    _, _, _, _, projs = make_misaligned_case(seed=9)
+    init_params5 = np.zeros((projs.shape[0], 5), dtype=np.float32)
+    init_params5[:, 0] = np.linspace(-0.02, 0.02, projs.shape[0], dtype=np.float32)
+    init_params5[:, 1] = np.linspace(0.01, -0.01, projs.shape[0], dtype=np.float32)
+    init_params5[:, 2] = np.linspace(-0.03, 0.03, projs.shape[0], dtype=np.float32)
+
+    params5, _ = _run_fixed_volume_alignment(
+        monkeypatch,
+        opt_method=opt_method,
+        views_per_batch=2,
+        loss_name=loss_name,
+        init_params5=jnp.asarray(init_params5),
+        optimise_dofs=("dx", "dz"),
+    )
+
+    np.testing.assert_array_equal(params5[:, :3], init_params5[:, :3])

--- a/tests/test_align_chunking.py
+++ b/tests/test_align_chunking.py
@@ -178,6 +178,84 @@ def test_align_optimise_only_dx_dz_keeps_rotations_initial(monkeypatch, opt_meth
     assert np.min(params5[:, 4]) >= -0.02 - 1e-6
 
 
+def test_align_polynomial_pose_model_returns_per_view_shape_and_variable_count(monkeypatch):
+    params5, info = _run_fixed_volume_alignment(
+        monkeypatch,
+        opt_method="gd",
+        views_per_batch=2,
+        loss_name="l2_otsu",
+        pose_model="polynomial",
+        degree=2,
+    )
+
+    assert params5.shape == (5, 5)
+    assert info["pose_model"] == "polynomial"
+    assert info["pose_model_basis_shape"] == [5, 3]
+    assert info["pose_model_variables"] == 15
+    assert info["per_view_variables"] == 25
+    assert info["pose_model_variables"] < info["per_view_variables"]
+
+
+@pytest.mark.parametrize(
+    ("opt_method", "loss_name"),
+    [
+        ("gd", "l2_otsu"),
+        ("gn", "l2"),
+    ],
+)
+def test_align_smooth_pose_model_keeps_frozen_dofs(monkeypatch, opt_method, loss_name):
+    _, _, _, _, projs = make_misaligned_case(seed=12)
+    init_params5 = np.zeros((projs.shape[0], 5), dtype=np.float32)
+    init_params5[:, 2] = np.linspace(-0.03, 0.03, projs.shape[0], dtype=np.float32)
+
+    params5, info = _run_fixed_volume_alignment(
+        monkeypatch,
+        opt_method=opt_method,
+        views_per_batch=2,
+        loss_name=loss_name,
+        init_params5=jnp.asarray(init_params5),
+        pose_model="polynomial",
+        degree=2,
+        freeze_dofs=("phi",),
+    )
+
+    assert info["pose_model"] == "polynomial"
+    np.testing.assert_array_equal(params5[:, 2], init_params5[:, 2])
+
+
+@pytest.mark.parametrize(
+    ("opt_method", "loss_name"),
+    [
+        ("gd", "l2_otsu"),
+        ("gn", "l2"),
+    ],
+)
+def test_align_smooth_pose_model_clips_active_bounds_only(monkeypatch, opt_method, loss_name):
+    _, _, _, _, projs = make_misaligned_case(seed=13)
+    init_params5 = np.zeros((projs.shape[0], 5), dtype=np.float32)
+    init_params5[:, 2] = np.linspace(-0.5, 0.5, projs.shape[0], dtype=np.float32)
+    init_params5[:, 3] = np.linspace(-0.5, 0.5, projs.shape[0], dtype=np.float32)
+    init_params5[:, 4] = np.linspace(0.4, -0.4, projs.shape[0], dtype=np.float32)
+
+    params5, _ = _run_fixed_volume_alignment(
+        monkeypatch,
+        opt_method=opt_method,
+        views_per_batch=2,
+        loss_name=loss_name,
+        init_params5=jnp.asarray(init_params5),
+        pose_model="polynomial",
+        degree=2,
+        freeze_dofs=("phi",),
+        bounds={"phi": (-0.01, 0.01), "dx": (-0.05, 0.05), "dz": (-0.04, 0.04)},
+    )
+
+    np.testing.assert_array_equal(params5[:, 2], init_params5[:, 2])
+    assert np.max(params5[:, 3]) <= 0.05 + 1e-6
+    assert np.min(params5[:, 3]) >= -0.05 - 1e-6
+    assert np.max(params5[:, 4]) <= 0.04 + 1e-6
+    assert np.min(params5[:, 4]) >= -0.04 - 1e-6
+
+
 @pytest.mark.parametrize(
     ("opt_method", "loss_name"),
     [

--- a/tests/test_align_chunking.py
+++ b/tests/test_align_chunking.py
@@ -168,6 +168,64 @@ def test_align_optimise_only_dx_dz_keeps_rotations_initial(monkeypatch, opt_meth
         loss_name=loss_name,
         init_params5=jnp.asarray(init_params5),
         optimise_dofs=("dx", "dz"),
+        bounds={"dx": (-0.01, 0.01), "dz": (-0.02, 0.02)},
     )
 
     np.testing.assert_array_equal(params5[:, :3], init_params5[:, :3])
+    assert np.max(params5[:, 3]) <= 0.01 + 1e-6
+    assert np.min(params5[:, 3]) >= -0.01 - 1e-6
+    assert np.max(params5[:, 4]) <= 0.02 + 1e-6
+    assert np.min(params5[:, 4]) >= -0.02 - 1e-6
+
+
+@pytest.mark.parametrize(
+    ("opt_method", "loss_name"),
+    [
+        ("gd", "l2_otsu"),
+        ("gn", "l2"),
+    ],
+)
+def test_align_bounds_clip_active_translations(monkeypatch, opt_method, loss_name):
+    _, _, _, _, projs = make_misaligned_case(seed=10)
+    init_params5 = np.zeros((projs.shape[0], 5), dtype=np.float32)
+    init_params5[:, 3] = np.linspace(-0.5, 0.5, projs.shape[0], dtype=np.float32)
+    init_params5[:, 4] = np.linspace(0.4, -0.4, projs.shape[0], dtype=np.float32)
+
+    params5, _ = _run_fixed_volume_alignment(
+        monkeypatch,
+        opt_method=opt_method,
+        views_per_batch=2,
+        loss_name=loss_name,
+        init_params5=jnp.asarray(init_params5),
+        bounds={"dx": (-0.05, 0.05), "dz": (-0.04, 0.04)},
+    )
+
+    assert np.max(params5[:, 3]) <= 0.05 + 1e-6
+    assert np.min(params5[:, 3]) >= -0.05 - 1e-6
+    assert np.max(params5[:, 4]) <= 0.04 + 1e-6
+    assert np.min(params5[:, 4]) >= -0.04 - 1e-6
+
+
+@pytest.mark.parametrize(
+    ("opt_method", "loss_name"),
+    [
+        ("gd", "l2_otsu"),
+        ("gn", "l2"),
+    ],
+)
+def test_align_bounds_do_not_clip_frozen_dofs(monkeypatch, opt_method, loss_name):
+    _, _, _, _, projs = make_misaligned_case(seed=11)
+    init_params5 = np.zeros((projs.shape[0], 5), dtype=np.float32)
+    init_params5[:, 2] = np.linspace(-0.5, 0.5, projs.shape[0], dtype=np.float32)
+
+    params5, _ = _run_fixed_volume_alignment(
+        monkeypatch,
+        opt_method=opt_method,
+        views_per_batch=2,
+        loss_name=loss_name,
+        init_params5=jnp.asarray(init_params5),
+        freeze_dofs=("phi",),
+        bounds={"phi": (-0.01, 0.01)},
+    )
+
+    np.testing.assert_array_equal(params5[:, 2], init_params5[:, 2])

--- a/tests/test_align_motion_models.py
+++ b/tests/test_align_motion_models.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import numpy as np
+import jax.numpy as jnp
+
+from tomojax.align.motion_models import (
+    build_pose_motion_model,
+    expand_motion_coefficients,
+    fit_motion_coefficients,
+    scan_coordinate_from_geometry,
+)
+
+
+class _GeometryWithAngles:
+    thetas_deg = np.linspace(0.0, 180.0, 10, endpoint=False)
+
+
+def _params(n_views: int) -> jnp.ndarray:
+    values = np.zeros((n_views, 5), dtype=np.float32)
+    values[:, 0] = np.linspace(-0.2, 0.2, n_views, dtype=np.float32)
+    values[:, 1] = np.linspace(0.3, -0.1, n_views, dtype=np.float32)
+    values[:, 2] = np.linspace(-0.5, 0.5, n_views, dtype=np.float32)
+    values[:, 3] = np.sin(np.linspace(0.0, np.pi, n_views)).astype(np.float32)
+    values[:, 4] = np.cos(np.linspace(0.0, np.pi, n_views)).astype(np.float32)
+    return jnp.asarray(values)
+
+
+def test_polynomial_motion_model_expands_to_per_view_params_shape():
+    n_views = 8
+    init = _params(n_views)
+    model = build_pose_motion_model(
+        pose_model="polynomial",
+        n_views=n_views,
+        active_dofs=("alpha", "beta", "phi", "dx", "dz"),
+        frozen_params5=jnp.zeros_like(init),
+        degree=2,
+    )
+
+    coeffs = fit_motion_coefficients(model, init)
+    expanded = expand_motion_coefficients(model, coeffs)
+
+    assert coeffs.shape == (3, 5)
+    assert expanded.shape == (n_views, 5)
+
+
+def test_spline_motion_model_expands_to_per_view_params_shape():
+    n_views = 10
+    init = _params(n_views)
+    scan = scan_coordinate_from_geometry(_GeometryWithAngles(), n_views)
+    model = build_pose_motion_model(
+        pose_model="spline",
+        n_views=n_views,
+        active_dofs=("alpha", "beta", "phi", "dx", "dz"),
+        frozen_params5=jnp.zeros_like(init),
+        scan_coordinate=scan,
+        knot_spacing=3,
+        degree=3,
+    )
+
+    coeffs = fit_motion_coefficients(model, init)
+    expanded = expand_motion_coefficients(model, coeffs)
+
+    assert coeffs.shape == (4, 5)
+    assert expanded.shape == (n_views, 5)
+
+
+def test_smooth_motion_model_uses_fewer_variables_than_per_view():
+    n_views = 10
+    init = jnp.zeros((n_views, 5), dtype=jnp.float32)
+    per_view = build_pose_motion_model(
+        pose_model="per_view",
+        n_views=n_views,
+        active_dofs=("dx", "dz"),
+        frozen_params5=init,
+    )
+    spline = build_pose_motion_model(
+        pose_model="spline",
+        n_views=n_views,
+        active_dofs=("dx", "dz"),
+        frozen_params5=init,
+        knot_spacing=5,
+        degree=3,
+    )
+
+    assert spline.variable_count < per_view.variable_count
+    assert spline.variable_count == 6
+    assert per_view.variable_count == 20
+
+
+def test_smooth_motion_model_preserves_frozen_dof_columns():
+    n_views = 9
+    frozen = _params(n_views)
+    target = frozen.at[:, 3].set(jnp.linspace(-1.0, 1.0, n_views))
+    model = build_pose_motion_model(
+        pose_model="polynomial",
+        n_views=n_views,
+        active_dofs=("dx",),
+        frozen_params5=frozen,
+        degree=2,
+    )
+
+    expanded = expand_motion_coefficients(model, fit_motion_coefficients(model, target))
+
+    np.testing.assert_array_equal(np.asarray(expanded[:, :3]), np.asarray(frozen[:, :3]))
+    np.testing.assert_array_equal(np.asarray(expanded[:, 4]), np.asarray(frozen[:, 4]))
+    assert model.variable_count == 3
+    assert model.per_view_variable_count == n_views

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -94,6 +94,81 @@ def test_align_cli_overrides_config_scalars_lists_booleans_and_append_values(tmp
     assert metadata["effective_options"]["levels"] == [2, 1]
 
 
+def test_align_cli_dof_options_parse_and_normalize_named_dofs():
+    parser = align_cli._build_parser()
+    args, _ = parse_args_with_config(
+        parser,
+        [
+            "--data",
+            "input.nxs",
+            "--out",
+            "runs/align.nxs",
+            "--optimise-dofs",
+            "dx,dz",
+            "--freeze-dofs",
+            "phi",
+        ],
+        required=("data", "out"),
+    )
+
+    optimise_dofs, freeze_dofs = align_cli._parse_dof_args(args, parser)
+
+    assert optimise_dofs == ("dx", "dz")
+    assert freeze_dofs == ("phi",)
+
+
+def test_align_config_toml_accepts_dof_arrays(tmp_path):
+    config_path = tmp_path / "align.toml"
+    config_path.write_text(
+        "\n".join(
+            [
+                'data = "input.nxs"',
+                'out = "runs/align.nxs"',
+                'optimise_dofs = ["dx", "dz"]',
+                'freeze_dofs = ["phi"]',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    parser = align_cli._build_parser()
+    args, metadata = parse_args_with_config(
+        parser,
+        ["--config", str(config_path)],
+        required=("data", "out"),
+    )
+    optimise_dofs, freeze_dofs = align_cli._parse_dof_args(args, parser)
+
+    assert metadata["config_file_values"]["optimise_dofs"] == ["dx", "dz"]
+    assert metadata["config_file_values"]["freeze_dofs"] == ["phi"]
+    assert optimise_dofs == ("dx", "dz")
+    assert freeze_dofs == ("phi",)
+
+
+def test_align_cli_rejects_unknown_dof_name(capsys):
+    parser = align_cli._build_parser()
+    args, _ = parse_args_with_config(
+        parser,
+        [
+            "--data",
+            "input.nxs",
+            "--out",
+            "runs/align.nxs",
+            "--optimise-dofs",
+            "theta",
+        ],
+        required=("data", "out"),
+    )
+
+    with pytest.raises(SystemExit):
+        align_cli._parse_dof_args(args, parser)
+
+    captured = capsys.readouterr()
+    assert "Unknown alignment DOF" in captured.err
+    assert "theta" in captured.err
+    assert "alpha" in captured.err
+
+
 def test_config_unknown_key_reports_useful_error(tmp_path, capsys):
     config_path = tmp_path / "bad.toml"
     config_path.write_text(

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 import tomojax.cli.align as align_cli
+from tomojax.align.dofs import normalize_bounds
 from tomojax.cli.config import parse_args_with_config
 import tomojax.cli.recon as recon_cli
 
@@ -167,6 +168,122 @@ def test_align_cli_rejects_unknown_dof_name(capsys):
     assert "Unknown alignment DOF" in captured.err
     assert "theta" in captured.err
     assert "alpha" in captured.err
+
+
+def test_normalize_bounds_accepts_cli_string_in_canonical_order():
+    bounds = normalize_bounds(
+        "dx=-20:20,dz=-10:10,alpha=-0.05:0.05",
+        option_name="--bounds",
+    )
+
+    assert bounds == (
+        ("alpha", -0.05, 0.05),
+        ("dx", -20.0, 20.0),
+        ("dz", -10.0, 10.0),
+    )
+
+
+def test_normalize_bounds_accepts_toml_style_mapping():
+    bounds = normalize_bounds(
+        {"dz": [-10, 10], "alpha": [-0.05, 0.05]},
+        option_name="bounds",
+    )
+
+    assert bounds == (
+        ("alpha", -0.05, 0.05),
+        ("dz", -10.0, 10.0),
+    )
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("theta=-1:1", "Unknown alignment DOF"),
+        ("dx=-1:1,dx=-2:2", "Duplicate alignment bounds"),
+        ("dx=1:1", "lower bound 1 must be less than upper bound 1"),
+        ("dx=-inf:1", "must be finite"),
+        ("dx=left:1", "is not numeric"),
+    ],
+)
+def test_normalize_bounds_rejects_invalid_values(raw, expected):
+    with pytest.raises(ValueError, match=expected):
+        normalize_bounds(raw, option_name="--bounds")
+
+
+def test_align_cli_bounds_option_parses_named_bounds():
+    parser = align_cli._build_parser()
+    args, metadata = parse_args_with_config(
+        parser,
+        [
+            "--data",
+            "input.nxs",
+            "--out",
+            "runs/align.nxs",
+            "--bounds",
+            "dx=-20:20,dz=-20:20,alpha=-0.05:0.05",
+        ],
+        required=("data", "out"),
+    )
+
+    assert args.bounds == (
+        ("alpha", -0.05, 0.05),
+        ("dx", -20.0, 20.0),
+        ("dz", -20.0, 20.0),
+    )
+    assert "bounds" in metadata["explicit_cli_keys"]
+
+
+def test_align_config_toml_accepts_bounds_mapping(tmp_path):
+    config_path = tmp_path / "align.toml"
+    config_path.write_text(
+        "\n".join(
+            [
+                'data = "input.nxs"',
+                'out = "runs/align.nxs"',
+                "bounds = { dx = [-20, 20], alpha = [-0.05, 0.05] }",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    parser = align_cli._build_parser()
+    args, metadata = parse_args_with_config(
+        parser,
+        ["--config", str(config_path)],
+        required=("data", "out"),
+    )
+
+    assert args.bounds == (
+        ("alpha", -0.05, 0.05),
+        ("dx", -20.0, 20.0),
+    )
+    assert metadata["config_file_values"]["bounds"] == (
+        ("alpha", -0.05, 0.05),
+        ("dx", -20.0, 20.0),
+    )
+
+
+def test_align_cli_rejects_invalid_bounds_before_main_work(capsys):
+    parser = align_cli._build_parser()
+
+    with pytest.raises(SystemExit):
+        parse_args_with_config(
+            parser,
+            [
+                "--data",
+                "input.nxs",
+                "--out",
+                "runs/align.nxs",
+                "--bounds",
+                "dx=20:-20",
+            ],
+            required=("data", "out"),
+        )
+
+    captured = capsys.readouterr()
+    assert "Invalid alignment bounds" in captured.err
+    assert "dx" in captured.err
+    assert "lower bound 20 must be less than upper bound -20" in captured.err
 
 
 def test_config_unknown_key_reports_useful_error(tmp_path, capsys):

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -4,6 +4,7 @@ import pytest
 
 import tomojax.cli.align as align_cli
 from tomojax.align.dofs import normalize_bounds
+from tomojax.align.pipeline import AlignConfig
 from tomojax.cli.config import parse_args_with_config
 import tomojax.cli.recon as recon_cli
 
@@ -261,6 +262,59 @@ def test_align_config_toml_accepts_bounds_mapping(tmp_path):
         ("alpha", -0.05, 0.05),
         ("dx", -20.0, 20.0),
     )
+
+
+def test_align_config_toml_accepts_and_cli_overrides_pose_model_options(tmp_path):
+    config_path = tmp_path / "align.toml"
+    config_path.write_text(
+        "\n".join(
+            [
+                'data = "input.nxs"',
+                'out = "runs/align.nxs"',
+                'pose_model = "spline"',
+                "knot_spacing = 6",
+                "degree = 3",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    parser = align_cli._build_parser()
+    args, metadata = parse_args_with_config(
+        parser,
+        [
+            "--config",
+            str(config_path),
+            "--pose-model",
+            "polynomial",
+            "--degree",
+            "2",
+        ],
+        required=("data", "out"),
+    )
+
+    assert args.pose_model == "polynomial"
+    assert args.knot_spacing == 6
+    assert args.degree == 2
+    assert metadata["config_file_values"]["pose_model"] == "spline"
+    assert metadata["config_file_values"]["knot_spacing"] == 6
+    assert metadata["config_file_values"]["degree"] == 3
+    assert "pose_model" in metadata["explicit_cli_keys"]
+    assert "degree" in metadata["explicit_cli_keys"]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    [
+        ({"pose_model": "not-a-model"}, "pose_model must be one of"),
+        ({"pose_model": "polynomial", "degree": -1}, "degree must be >= 0"),
+        ({"pose_model": "spline", "knot_spacing": 0}, "knot_spacing must be >= 1"),
+        ({"pose_model": "spline", "degree": 4}, "degree must be one of"),
+    ],
+)
+def test_align_config_rejects_invalid_pose_model_options(kwargs, expected):
+    with pytest.raises(ValueError, match=expected):
+        AlignConfig(**kwargs)
 
 
 def test_align_cli_rejects_invalid_bounds_before_main_work(capsys):

--- a/tests/test_cli_entrypoints.py
+++ b/tests/test_cli_entrypoints.py
@@ -68,6 +68,18 @@ def test_recon_help_documents_quicklook_aliases(monkeypatch, capsys):
     assert "--save-preview" in captured.out
 
 
+def test_align_help_documents_bounds_example(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["tomojax-align", "--help"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        align_cli.main()
+
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    assert "--bounds" in captured.out
+    assert "dx=-20:20,dz=-20:20,alpha=-0.05:0.05" in captured.out
+
+
 def test_recon_views_per_batch_parser_accepts_auto_and_integers():
     assert recon_cli._parse_views_per_batch("auto") == "auto"
     assert recon_cli._parse_views_per_batch("AUTO") == "auto"
@@ -313,6 +325,7 @@ def test_align_main_writes_parameter_sidecars_from_returned_params(monkeypatch, 
         captured["align_grid"] = recon_grid
         captured["align_detector"] = recon_detector
         captured["align_projections_shape"] = tuple(projections.shape)
+        captured["align_cfg"] = cfg
         x = jnp.zeros((recon_grid.nx, recon_grid.ny, recon_grid.nz), dtype=jnp.float32)
         info = {
             "loss": [1.0],
@@ -358,6 +371,7 @@ def test_align_main_writes_parameter_sidecars_from_returned_params(monkeypatch, 
                 'roi = "off"',
                 'gather_dtype = "bf16"',
                 'transfer_guard = "off"',
+                "bounds = { dx = [-20, 20], alpha = [-0.05, 0.05] }",
                 f'save_params_json = "{json_path}"',
                 f'save_params_csv = "{csv_path}"',
                 f'save_manifest = "{manifest_path}"',
@@ -384,6 +398,10 @@ def test_align_main_writes_parameter_sidecars_from_returned_params(monkeypatch, 
     assert captured["transfer_guard"] == "log"
     assert captured["save_path"] == str(out_path)
     assert captured["save_projections_shape"] == (2, 1, 2)
+    assert captured["align_cfg"].bounds == (
+        ("alpha", -0.05, 0.05),
+        ("dx", -20.0, 20.0),
+    )
     saved_meta = captured["save_metadata"]
     np.testing.assert_allclose(np.asarray(saved_meta.align_params), np.asarray(params5))
     assert json_path.exists()
@@ -408,6 +426,10 @@ def test_align_main_writes_parameter_sidecars_from_returned_params(monkeypatch, 
     assert manifest["resolved_config"]["output_path"] == str(out_path)
     assert manifest["resolved_config"]["config_path"] == str(config_path)
     assert manifest["resolved_config"]["config_file_values"]["gather_dtype"] == "bf16"
+    assert manifest["resolved_config"]["config_file_values"]["bounds"] == [
+        ["alpha", -0.05, 0.05],
+        ["dx", -20.0, 20.0],
+    ]
     assert "gather_dtype" in manifest["resolved_config"]["explicit_cli_keys"]
     assert manifest["resolved_config"]["effective_options"]["gather_dtype"] == "fp32"
     assert manifest["resolved_config"]["gather_dtype"] == "fp32"

--- a/tests/test_cli_entrypoints.py
+++ b/tests/test_cli_entrypoints.py
@@ -78,6 +78,7 @@ def test_align_help_documents_bounds_example(monkeypatch, capsys):
     captured = capsys.readouterr()
     assert "--bounds" in captured.out
     assert "dx=-20:20,dz=-20:20,alpha=-0.05:0.05" in captured.out
+    assert "--pose-model" in captured.out
 
 
 def test_recon_views_per_batch_parser_accepts_auto_and_integers():
@@ -372,6 +373,9 @@ def test_align_main_writes_parameter_sidecars_from_returned_params(monkeypatch, 
                 'gather_dtype = "bf16"',
                 'transfer_guard = "off"',
                 "bounds = { dx = [-20, 20], alpha = [-0.05, 0.05] }",
+                'pose_model = "spline"',
+                "knot_spacing = 5",
+                "degree = 2",
                 f'save_params_json = "{json_path}"',
                 f'save_params_csv = "{csv_path}"',
                 f'save_manifest = "{manifest_path}"',
@@ -402,6 +406,9 @@ def test_align_main_writes_parameter_sidecars_from_returned_params(monkeypatch, 
         ("alpha", -0.05, 0.05),
         ("dx", -20.0, 20.0),
     )
+    assert captured["align_cfg"].pose_model == "spline"
+    assert captured["align_cfg"].knot_spacing == 5
+    assert captured["align_cfg"].degree == 2
     saved_meta = captured["save_metadata"]
     np.testing.assert_allclose(np.asarray(saved_meta.align_params), np.asarray(params5))
     assert json_path.exists()
@@ -430,6 +437,8 @@ def test_align_main_writes_parameter_sidecars_from_returned_params(monkeypatch, 
         ["alpha", -0.05, 0.05],
         ["dx", -20.0, 20.0],
     ]
+    assert manifest["resolved_config"]["config_file_values"]["pose_model"] == "spline"
+    assert manifest["resolved_config"]["align_config"]["pose_model"] == "spline"
     assert "gather_dtype" in manifest["resolved_config"]["explicit_cli_keys"]
     assert manifest["resolved_config"]["effective_options"]["gather_dtype"] == "fp32"
     assert manifest["resolved_config"]["gather_dtype"] == "fp32"


### PR DESCRIPTION
## Summary
- Add optional low-dimensional pose models for alignment: `per_view`, `polynomial`, and `spline`
- Keep per-view alignment as the default while expanding smooth coefficients back to per-view `params5` for projection, export, and saved `.nxs` output
- Preserve DOF masking and frozen-column behavior, and expose pose-model metadata in alignment results
- Update CLI/docs/config examples and add regression coverage for model size, frozen DOFs, and output shape

## Testing
- `uv run ruff check src/tomojax/align/motion_models.py src/tomojax/align/pipeline.py src/tomojax/cli/align.py tests/test_align_motion_models.py tests/test_align_chunking.py tests/test_cli_config.py tests/test_cli_entrypoints.py`
- `uv run pytest -q tests/test_align_chunking.py tests/test_align_quick.py tests/test_cli_config.py tests/test_cli_entrypoints.py tests/test_align_motion_models.py tests/test_align_params_export.py tests/test_integration.py`
- CPU experiments on small synthetic datasets, including 64³ cases with frozen reconstruction