### PR TITLE
Add profile-driven early-stop policy for alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ verification utilities, and troubleshooting.
   with Gauss-Newton, gradient descent, or L-BFGS optimisers
 - **Multi-resolution alignment** with coarse-to-fine pyramid
   (e.g. 4x, 2x, 1x) and alternating reconstruct/align steps
+- **Profiled alignment early stopping** with compute-saving defaults
+  and a conservative `robust` profile for final real-data runs
 - **Three reconstruction algorithms**: FBP, FISTA-TV, and SPDHG-TV
   with automatic Lipschitz estimation and TV proximal operators
 - **Laminography support** with tilted rotation-axis geometry,

--- a/docs/brainstorms/geometry-calibration-solver-requirements.md
+++ b/docs/brainstorms/geometry-calibration-solver-requirements.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-04-24
-last_updated: 2026-04-27
+last_updated: 2026-05-01
 topic: unified-alignment-state-geometry-calibration
 ---
 
@@ -238,6 +238,10 @@ The branch now has the production shape described above:
   `optimizer_kind="validation_lm"`, `recon_sensitivity="stopped"`,
   `fold_eval_mode="stopped_train_recon_validation_lm"`, and
   `active_gradient_mode="validation_residual_jvp"`.
+- Alignment early stopping now resolves through shared policy profiles:
+  `compute_saving` is the default, `robust` is the conservative opt-in, and
+  setup stages stop on accepted validation-LM step evidence rather than
+  cross-outer reconstruction/loss drift.
 - Direct mixed setup+pose active DOF sets reject by default unless an explicit
   expert gauge policy is supplied.
 - CLI, API, checkpoint metadata, and the canonical evidence generator record the

--- a/docs/plans/2026-04-29-002-feat-alignment-early-stop-profiles-plan.md
+++ b/docs/plans/2026-04-29-002-feat-alignment-early-stop-profiles-plan.md
@@ -1,0 +1,433 @@
+---
+title: feat: Add Alignment Early Stop Profiles
+type: feat
+status: completed
+date: 2026-04-29
+origin: docs/brainstorms/geometry-calibration-solver-requirements.md
+---
+
+# feat: Add Alignment Early Stop Profiles
+
+## Summary
+
+Add a shared early-stop policy layer for alignment setup and pose stages, with a compute-saving default profile and a conservative `robust` profile for runs where false stopping is more expensive than extra iterations. The policy should stop on multi-signal evidence from accepted optimizer gain, step size, optimizer health, and stage-specific tolerances instead of comparing drift in total loss across outer iterations.
+
+---
+
+## Problem Frame
+
+The recent real laminography runs show setup stages where the loss continues drifting by tiny amounts while checkpoint previews barely change. COR stages can justify small continued movement, but detector roll and later polish stages can spend long periods chasing numerical improvement that is not visually or physically meaningful. The current setup early stop is also not aligned with the validation-LM contract: it compares one outer's `geometry_loss_after` to the next outer's `geometry_loss_after`, so reconstruction refresh drift can keep a marginal geometry stage alive even when accepted geometry updates are tiny.
+
+This plan extends the unified alignment-state requirement that geometry and pose share multiresolution execution semantics, early stopping, checkpointing, and diagnostics (see origin: `docs/brainstorms/geometry-calibration-solver-requirements.md`).
+
+---
+
+## Requirements
+
+- R1. Early stopping must be implemented as shared alignment policy behavior, not as runner-only logic, so setup geometry and pose stages follow one auditable contract.
+- R2. The default early-stop profile must be compute-saving: marginal stages should stop when accepted optimizer gain and parameter movement are both too small for the active DOFs.
+- R3. A conservative profile, exposed as `robust` or a similarly clear name, must be available for production or expensive real-data runs where uncertain stages should continue longer.
+- R4. Setup geometry early stopping must evaluate accepted validation-LM step evidence within the same objective context, using `geometry_loss_before`, `geometry_loss_after`, `geometry_accepted`, step norms, selected LM scale, and optimizer conditioning.
+- R5. Pose early stopping must keep using same-volume pre/post alignment improvement, but should also consider pose movement magnitude and optimizer acceptance where available.
+- R6. Stage stats, manifests, checkpoints, and runner CSV summaries must record enough early-stop telemetry to explain why a stage continued or stopped.
+- R7. Existing `--early-stop`, `--no-early-stop`, `--early-stop-rel`, and `--early-stop-patience` behavior must remain backward-compatible, with new profile controls layered on top.
+- R8. The real-laminography runner must use the same policy semantics as the package alignment path, or explicitly call into the shared policy helper, so laptop runs do not diverge from `tomojax-align`.
+- R9. Tests must cover plateau, accepted-small-step, rejected-update, optimizer-health, profile-default, and checkpoint/resume bookkeeping cases.
+
+**Origin actors:** A1 TomoJAX user, A2 Alignment engine, A3 Planner/implementer, A4 Documentation/demo generator.
+**Origin flows:** F1 COR-only detector-centre alignment, F2 Pose-only alignment, F3 Staged geometry plus pose alignment, F4 Demo/evidence generation.
+**Origin acceptance examples:** AE1, AE2, AE3, AE4, AE5, AE6.
+
+---
+
+## Scope Boundaries
+
+- This plan does not change reconstruction or FISTA-TV early stopping in `src/tomojax/recon/`.
+- This plan does not alter alignment loss definitions such as `l2_otsu`, `phasecorr`, or their adapter semantics.
+- This plan does not introduce image-preview-based early stopping; preview and ROI metrics may be logged later, but the stop decision should remain optimizer/objective based.
+- This plan does not change gauge policy decisions or allow unsafe coupled setup/pose solves.
+- This plan does not tune a final set of universal numeric thresholds from first principles; implementation should define reasonable defaults and make the thresholds profile/config driven.
+
+### Deferred to Follow-Up Work
+
+- Preview-derived quality metrics for dashboards: defer until the optimizer-level policy is stable.
+- Per-dataset auto-tuning from historical run logs: defer until the new telemetry exists across several runs.
+- A separate run-comparison report generator for early-stop diagnostics: defer to a later visualization/reporting task.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/tomojax/align/_config.py` owns `AlignConfig.early_stop`, `early_stop_rel_impr`, and `early_stop_patience`; this is the right public config surface to extend.
+- `src/tomojax/cli/align.py` exposes `--early-stop`, `--no-early-stop`, `--early-stop-rel`, and `--early-stop-patience`; new profile flags should preserve these options.
+- `src/tomojax/align/_setup_stage.py` currently performs setup early stopping by comparing previous `geometry_loss_after` to current `geometry_loss_after`, which is the main bug-shaped behavior to replace.
+- `src/tomojax/align/_pose_stage.py` currently tracks `rel_impr` and `small_impr_streak`; this should be adapted rather than discarded.
+- `src/tomojax/align/optimizers.py` already emits validation-LM evidence such as `optimizer_accepted`, `optimizer_actual_reduction`, `optimizer_selected_scale`, `optimizer_condition_number`, `step_norm_whitened`, and native step stats.
+- `src/tomojax/align/geometry/geometry_blocks.py` already summarizes accepted geometry updates, total step norms, gradients, and block status; the new policy should reuse this diagnostic vocabulary where possible.
+- `src/tomojax/align/_results.py` and `src/tomojax/align/io/checkpoint.py` carry `small_impr_streak` through result/checkpoint state; any new early-stop state must preserve resume behavior.
+- `scripts/real_laminography/run_real_lamino_native_setup_pose_256.py` has runner-local setup early stopping and `stage_summary.csv` fields; it should stop duplicating divergent logic.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture-patterns/reuse-align-multires-for-geometry-calibration-2026-04-25.md`: setup geometry belongs inside the unified alignment system, with stopped train-fold reconstruction and validation-LM evidence, not a private solver or private objective.
+- `docs/solutions/logic-errors/fista-square-artifacts-from-uncentered-lamino-projections-2026-04-29.md`: real-data runs can look numerically alive while previews are clearly wrong, so telemetry must make optimizer behavior explainable and should not hide preprocessing/config problems behind loss drift.
+
+### External References
+
+- None used. The codebase already has the relevant optimizer diagnostics, stage loop structure, and institutional learnings; external research would add little compared with aligning the implementation to local contracts.
+
+---
+
+## Key Technical Decisions
+
+- Use profile names rather than a single stricter threshold: `compute_saving` as the default and `robust` as the conservative option give users intent-level control while preserving low-level threshold overrides.
+- Put policy evaluation in a small shared module under `src/tomojax/align/`, not inside `_setup_stage.py` or `_pose_stage.py`, so setup, pose, CLI, runner scripts, and tests use the same stop-state vocabulary.
+- Treat accepted step evidence as primary for setup stages: `geometry_loss_before - geometry_loss_after` measures the candidate validation-LM update under the same fold volumes, while cross-outer `geometry_loss_after` drift can include reconstruction refresh effects.
+- Keep pose loss improvement as a valid signal, but augment it with movement and acceptance evidence; pose updates still operate in a fixed-volume local objective where pre/post step loss has useful semantics.
+- Log stop decisions every outer, not only when stopping, so a live run can explain why early stopping is not firing.
+- Preserve legacy flags by mapping `--early-stop-rel` and `--early-stop-patience` into the selected profile's threshold fields rather than removing them.
+
+### Profile Comparison
+
+| Profile | Intended use | Stop posture | Typical behavior |
+|---|---|---|---|
+| `compute_saving` | Default exploratory and iterative real-data runs | Stop when accepted gain and active-step movement are both small for the stage | Detector roll and light polish stop earlier; COR still gets enough warmup to move if meaningful |
+| `robust` | Production, final evidence runs, or uncertain real data | Require more patience and stronger agreement before stopping | More likely to complete allowed outers when optimizer evidence is ambiguous |
+| `off` | Debugging or forced full schedules | Disable early-stop decisions | Existing `--no-early-stop` behavior remains available |
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should there be two profiles? Yes. The user chose two profiles, with compute-saving as default and a conservative `robust` option.
+- Should `robust` be the default? No. The default should save compute; `robust` is opt-in for conservative runs.
+- Should image previews drive stopping? No. Recent previews motivated the work, but optimizer and objective evidence should remain the stop authority.
+
+### Deferred to Implementation
+
+- Exact threshold values for per-stage movement and accepted gain: choose initial values during implementation using existing units/scales and keep them configurable.
+- Exact flag spelling: `--early-stop-profile robust` is the likely shape, but implementation should choose the smallest backward-compatible CLI surface that fits parser conventions.
+- Whether to persist early-stop state as a richer dataclass or continue through result dictionaries: choose based on the smallest change that preserves checkpoint compatibility.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+    Config[AlignConfig + CLI profile] --> Policy[Early stop policy resolver]
+    StageStats[Setup or pose outer stat] --> Evidence[Evidence extraction]
+    Policy --> Decision[Continue / stop decision]
+    Evidence --> Decision
+    Decision --> StageLoop[Setup and pose stage loops]
+    Decision --> Telemetry[Outer stats, CSV, checkpoint metadata]
+    StageLoop --> Checkpoint[Resume state preserves streaks]
+```
+
+The policy should evaluate one outer iteration at a time and return a decision object with at least: `should_stop`, `reason`, profile name, streak counters, active evidence values, and thresholds used. Setup and pose stages should differ only in evidence extraction and profile thresholds, not in ad hoc control flow.
+
+---
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+    U1[U1 Policy model] --> U2[U2 Setup integration]
+    U1 --> U3[U3 Pose integration]
+    U2 --> U4[U4 CLI and runner parity]
+    U3 --> U4
+    U1 --> U5[U5 Tests]
+    U2 --> U5
+    U3 --> U5
+    U4 --> U5
+    U5 --> U6[U6 Docs and run notes]
+```
+
+- U1. **Define Shared Early-Stop Policy Model**
+
+**Goal:** Introduce a reusable policy/evidence model that can evaluate setup and pose outer stats without depending on a specific stage loop.
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R7
+
+**Dependencies:** None
+
+**Files:**
+- Create: `src/tomojax/align/early_stop.py`
+- Modify: `src/tomojax/align/_config.py`
+- Modify: `src/tomojax/align/_results.py`
+- Modify: `src/tomojax/align/io/checkpoint.py`
+- Test: `tests/test_align_early_stop.py`
+
+**Approach:**
+- Add an early-stop profile config field to `AlignConfig`, with a default compute-saving profile and an opt-in robust profile.
+- Model stop evidence separately from stop state. Evidence should include accepted relative gain, total relative gain when meaningful, whitened/native step size, active DOF names, optimizer acceptance, selected scale, condition number, and non-finite status.
+- Model state as named streak counters rather than a single `small_impr_streak`: for example gain plateau, tiny step, rejected update, unhealthy optimizer, and non-finite loss. The final implementation can keep one serialized dict if that is lighter than adding several checkpoint fields.
+- Preserve backward compatibility by allowing existing `early_stop_rel_impr` and `early_stop_patience` to override profile thresholds.
+- Make profile resolution deterministic and serializable so manifests/checkpoints can record the resolved policy.
+
+**Execution note:** Start with unit tests for pure policy evaluation before wiring it into JAX-heavy alignment paths.
+
+**Patterns to follow:**
+- `src/tomojax/align/model/schedules.py` for small serializable config objects and preset/profile resolution.
+- `src/tomojax/align/_results.py` for defensive conversion of stats into serializable values.
+- `src/tomojax/align/io/checkpoint.py` for backward-compatible checkpoint metadata defaults.
+
+**Test scenarios:**
+- Happy path: compute-saving setup evidence with accepted gain above threshold and meaningful step returns continue and resets plateau counters.
+- Happy path: robust setup evidence with the same marginal gain that compute-saving stops on returns continue until the robust patience is reached.
+- Edge case: missing optional fields such as condition number or selected scale do not crash policy evaluation and produce explicit `unknown` evidence values.
+- Edge case: `early_stop=False` or profile `off` returns continue with reason `disabled`.
+- Error path: non-finite loss or non-finite gain increments the non-finite counter and stops with a clear reason after the configured patience.
+- Integration: checkpoint serialization can load older checkpoints without early-stop policy state and resume with default counters.
+
+**Verification:**
+- Policy tests pass without invoking GPU/JAX-heavy reconstruction.
+- Resolved profile settings are serializable and appear in stats or metadata in a stable form.
+
+---
+
+- U2. **Replace Setup Geometry Early Stop With Accepted-Step Evidence**
+
+**Goal:** Update setup geometry stages to stop based on validation-LM evidence within the same objective context, eliminating cross-outer loss drift as the primary signal.
+
+**Requirements:** R1, R2, R4, R6, R8, R9
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `src/tomojax/align/_setup_stage.py`
+- Modify: `src/tomojax/align/_stage_loop.py`
+- Modify: `src/tomojax/align/geometry/geometry_blocks.py`
+- Test: `tests/test_bilevel_setup_alignment.py`
+- Test: `tests/test_align_early_stop.py`
+
+**Approach:**
+- Build setup evidence from `_build_geometry_stage_stat` output, using `geometry_loss_before`, `geometry_loss_after`, `geometry_accepted`, `geometry_step_norm`, `geometry_gradient_norm`, `optimizer_selected_scale`, `optimizer_actual_reduction`, and `optimizer_condition_number`.
+- Compute `accepted_geometry_rel_impr` from the same stat's before/after loss when the update was accepted. Do not use previous outer `geometry_loss_after` as the main plateau signal.
+- Keep optional `loss_drift_from_prev_after` as telemetry, because it is useful for diagnosing reconstruction refresh effects, but do not let that drift alone keep a stage alive.
+- Record `early_stop_profile`, `early_stop_decision`, `early_stop_reason`, `early_stop_gain_streak`, `early_stop_step_streak`, and thresholds in each setup stat.
+- Ensure setup-level early-stop state resets at appropriate boundaries: new stage, new level, or explicit stage resume. It should not accidentally carry detector-roll plateau into COR refresh.
+- Feed the richer decision status into geometry calibration summaries where useful, without changing the existing high-level diagnostics contract.
+
+**Patterns to follow:**
+- Existing `_build_geometry_stage_stat` stat enrichment in `src/tomojax/align/_setup_stage.py`.
+- Validation-LM optimizer stats from `src/tomojax/align/optimizers.py`.
+- Geometry summary status aggregation in `src/tomojax/align/geometry/geometry_blocks.py`.
+
+**Test scenarios:**
+- Happy path: accepted setup update with meaningful `optimizer_actual_reduction` and `geometry_step_norm` continues and records `early_stop_decision=continue`.
+- Happy path: repeated accepted setup updates with tiny accepted relative gain and tiny step stop under compute-saving profile after patience.
+- Edge case: repeated rejected validation-LM updates stop with reason indicating no accepted update, not generic low improvement.
+- Edge case: a new level resets setup early-stop streaks even if the previous level stopped early.
+- Error path: ill-conditioned validation-LM evidence increments optimizer-health streak and eventually stops or marks the reason according to policy.
+- Integration: `align_multires(... optimise_dofs=("det_u_px",), early_stop=True)` emits setup stats with the new early-stop telemetry and still preserves AE1 setup provenance.
+
+**Verification:**
+- Setup stages no longer depend on previous outer `geometry_loss_after` drift to decide plateau.
+- Existing setup validation-LM tests still confirm `active_gradient_mode=validation_residual_jvp` and `schedule_stage_name` provenance.
+
+---
+
+- U3. **Augment Pose Early Stop With Movement And Acceptance Evidence**
+
+**Goal:** Keep pose early stopping compatible with existing loss-improvement semantics while making it more robust for polish stages and smooth pose models.
+
+**Requirements:** R1, R2, R5, R6, R7, R9
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `src/tomojax/align/_pose_stage.py`
+- Modify: `src/tomojax/align/_results.py`
+- Test: `tests/test_align_quick.py`
+- Test: `tests/test_align_early_stop.py`
+- Test: `tests/test_align_checkpoint.py`
+
+**Approach:**
+- Extract pose evidence after `_run_alignment_step`: `rel_impr`, `loss_before`, `loss_after`, `step_kind`, `rot_mean`, `trans_mean`, `rot_rms`, `trans_rms`, LBFGS acceptance, and gauge-fix stats when available.
+- Normalize movement evidence by active DOF type so translation-only stages are not judged by absent rotation stats and phi-only stages are not judged by absent translation stats.
+- Keep `early_stop_rel_impr` as a legacy gain threshold, but require movement/acceptance evidence to agree before stopping under compute-saving profile.
+- Under `robust`, require either longer patience or stronger evidence agreement before stopping pose stages.
+- Preserve observer stop behavior: observer actions should still be able to stop a level/run independently of early-stop policy.
+
+**Patterns to follow:**
+- Existing `rel_impr` and `small_impr_streak` logic in `src/tomojax/align/_pose_stage.py`.
+- Existing gauge-fix stats emitted by pose constraints.
+- Checkpoint resume state in `src/tomojax/align/_stage_loop.py`.
+
+**Test scenarios:**
+- Happy path: pose stage with meaningful relative improvement continues and resets gain plateau streak.
+- Happy path: pose polish with tiny gain and tiny active movement stops under compute-saving profile.
+- Edge case: translation-only active DOFs use translation movement evidence and do not require rotation stats.
+- Edge case: phi-only active DOF uses rotational movement evidence and does not require translation stats.
+- Error path: LBFGS rejected update with no movement increments the rejected-update streak and stops after patience.
+- Integration: observer stop still wins when observer requests stop before early-stop patience is reached.
+- Integration: checkpoint/resume carries the new early-stop state or safely maps old `small_impr_streak` into the new state.
+
+**Verification:**
+- Pose-only alignment behavior remains backward-compatible when early stopping is disabled.
+- Existing pose tests continue to pass with `early_stop=False`.
+
+---
+
+- U4. **Expose Profiles Through CLI, Manifests, And Real-Laminography Runner**
+
+**Goal:** Make the new policy usable and inspectable from `tomojax-align`, evidence scripts, and the real laminography runner used for laptop jobs.
+
+**Requirements:** R2, R3, R6, R7, R8, R9
+
+**Dependencies:** U1, U2, U3
+
+**Files:**
+- Modify: `src/tomojax/cli/align.py`
+- Modify: `scripts/generate_alignment_before_after_128.py`
+- Modify: `scripts/real_laminography/run_real_lamino_native_setup_pose_256.py`
+- Modify: `scripts/alignment_visuals.py`
+- Test: `tests/test_align_contracts.py`
+- Test: `tests/test_geometry_block_taxonomy_generator.py`
+
+**Approach:**
+- Add a CLI flag such as `--early-stop-profile {compute_saving,robust}` while keeping `--early-stop`, `--no-early-stop`, `--early-stop-rel`, and `--early-stop-patience` working.
+- Record the resolved profile and thresholds in alignment info, run manifests, and stage manifests.
+- Replace the real-laminography runner's local stale-loss calculation with shared policy evaluation or a thin adapter over the shared policy module.
+- Expand `stage_summary.csv` fields to include accepted gain, step evidence, stop reason, decision, profile, and relevant streak counters.
+- Update evidence/demo profile dataclasses so generated manifests preserve the selected profile.
+
+**Patterns to follow:**
+- Existing CLI parser defaults and `AlignConfig` construction in `src/tomojax/cli/align.py`.
+- Existing manifest profile fields in `scripts/generate_alignment_before_after_128.py`.
+- Existing runner `stage_summary.csv` append pattern in `scripts/real_laminography/run_real_lamino_native_setup_pose_256.py`.
+
+**Test scenarios:**
+- Happy path: default CLI construction resolves to compute-saving profile with early stopping enabled.
+- Happy path: `--early-stop-profile robust` reaches `AlignConfig` and is serialized into metadata.
+- Edge case: `--no-early-stop` disables policy decisions even when a profile is also configured.
+- Edge case: `--early-stop-rel` and `--early-stop-patience` override the profile's gain threshold and patience without changing the profile name.
+- Integration: real-laminography runner stage summaries include new policy columns for setup stages.
+- Integration: evidence generator manifests record the selected profile and remain backward-compatible with existing profile fixtures.
+
+**Verification:**
+- Users can see which profile was used from artifacts alone.
+- Laptop runner behavior matches package alignment behavior for the same setup stats.
+
+---
+
+- U5. **Add Characterization And Regression Coverage**
+
+**Goal:** Ensure the policy catches the failure modes observed in recent runs while protecting existing alignment contracts.
+
+**Requirements:** R1, R4, R5, R6, R7, R8, R9
+
+**Dependencies:** U1, U2, U3, U4
+
+**Files:**
+- Create: `tests/test_align_early_stop.py`
+- Modify: `tests/test_bilevel_setup_alignment.py`
+- Modify: `tests/test_align_quick.py`
+- Modify: `tests/test_align_checkpoint.py`
+- Modify: `tests/test_align_contracts.py`
+
+**Approach:**
+- Keep most tests pure and CPU-friendly by testing policy decisions with small dictionaries rather than full reconstructions.
+- Add focused integration tests only where policy wiring could diverge: one setup validation-LM run, one pose run, one checkpoint/resume metadata case, and one CLI/config mapping case.
+- Use synthetic stats that mirror the recent real-run pattern: total level loss drifts down across outers, but accepted geometry step improvements are microscopic. The expected result should be stop under compute-saving and continue longer under robust.
+- Include coverage for profile/metadata fields so future runs explain why early stopping did or did not fire.
+
+**Patterns to follow:**
+- CPU-sized synthetic geometry helpers in `tests/test_bilevel_setup_alignment.py`.
+- Alignment config contract tests in `tests/test_align_contracts.py`.
+- Checkpoint metadata tests in `tests/test_align_checkpoint.py`.
+
+**Test scenarios:**
+- Happy path: compute-saving profile stops detector-roll-like setup evidence with sub-threshold accepted gains despite cross-outer loss drift.
+- Happy path: robust profile does not stop the same evidence until its larger patience requirement is met.
+- Edge case: COR-like setup evidence with small but still meaningful active step continues under compute-saving until movement becomes tiny.
+- Edge case: stage and level transitions reset policy streaks.
+- Error path: missing legacy checkpoint fields load with default early-stop state rather than raising.
+- Integration: `tomojax-align` config construction preserves existing defaults when no new flags are passed.
+
+**Verification:**
+- The test suite proves the precise regression from recent runs: total loss drift alone cannot keep a setup stage alive.
+- Feature-bearing units have both pure policy coverage and at least one end-to-end wiring check.
+
+---
+
+- U6. **Document Policy Semantics And Run Interpretation**
+
+**Goal:** Capture the operational meaning of the profiles so future run monitoring can interpret loss curves and early-stop decisions correctly.
+
+**Requirements:** R3, R6, R7, R8
+
+**Dependencies:** U1, U2, U3, U4, U5
+
+**Files:**
+- Modify: `docs/brainstorms/geometry-calibration-solver-requirements.md`
+- Create: `docs/solutions/architecture-patterns/alignment-early-stop-policy-profiles-2026-04-29.md`
+- Modify: `README.md`
+
+**Approach:**
+- Update the requirements doc's implementation-state notes only if the implementation changes the durable architecture.
+- Add a solution note explaining why setup stages should stop on accepted validation-LM step evidence and why cross-outer loss drift is diagnostic rather than authoritative.
+- Document the default compute-saving profile and the robust profile in user-facing CLI docs.
+- Include guidance for run monitoring: report accepted gain, step norm, selected scale, condition number, and early-stop reason instead of only total loss.
+
+**Patterns to follow:**
+- Existing solution-note structure in `docs/solutions/architecture-patterns/reuse-align-multires-for-geometry-calibration-2026-04-25.md`.
+- Existing README CLI examples and option descriptions.
+
+**Test scenarios:**
+- Test expectation: none -- documentation-only unit, covered by review and by the implementation tests in U1-U5.
+
+**Verification:**
+- A user reading artifacts and docs can explain why a stage continued despite tiny visual change, or why it stopped early.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** `AlignConfig` and CLI parsing feed setup and pose stage loops; stage loops emit stats into multires results, checkpoints, manifests, real-laminography CSVs, and monitoring scripts.
+- **Error propagation:** Non-finite losses or malformed stats should produce explicit policy reasons in telemetry and stop safely according to profile thresholds, not crash in reporting code.
+- **State lifecycle risks:** Early-stop streaks must reset across stages and levels, but checkpoint/resume must preserve in-stage streaks. Old checkpoints without policy state must remain loadable.
+- **API surface parity:** `tomojax-align`, generated evidence scripts, and the real-laminography runner should expose and record the same profile semantics.
+- **Integration coverage:** Unit policy tests are insufficient by themselves; at least one setup integration and one pose integration should prove wiring.
+- **Unchanged invariants:** Loss adapters, gauge policy validation, setup validation-LM objective provenance, and pose DOF semantics must not change.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|---|---|
+| Thresholds stop a COR stage too early | Use stage/DOF-specific thresholds and make `robust` available; require meaningful movement evidence as well as gain evidence. |
+| Thresholds keep detector roll running too long | Compute-saving profile should stop when accepted gain and active step are both microscopic, even if total loss drifts. |
+| New checkpoint state breaks resume compatibility | Default missing fields when loading old checkpoints and test that path explicitly. |
+| Runner and package behavior diverge again | Make the runner call the shared policy helper or a thin shared adapter; test the fields it writes. |
+| Telemetry becomes noisy and hard to monitor | Use stable field names and group all policy fields under an obvious `early_stop_*` prefix. |
+| Profile overrides confuse legacy users | Keep legacy flags valid, document override precedence, and record resolved thresholds in metadata. |
+
+---
+
+## Documentation / Operational Notes
+
+- Run monitoring should report accepted step improvement and policy reason alongside total loss. For recent TEM-grid runs, the important distinction is "loss still drifting" versus "accepted geometry step is too small to matter".
+- The default should be compute-saving because exploratory real-data work needs fast feedback. Use `robust` for final evidence runs, ambiguous setup stages, or when a false stop would be more expensive than extra GPU time.
+- Do not remove `--no-early-stop`; it remains useful for debugging solver behavior and generating full loss traces.
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/geometry-calibration-solver-requirements.md](docs/brainstorms/geometry-calibration-solver-requirements.md)
+- Related learning: [docs/solutions/architecture-patterns/reuse-align-multires-for-geometry-calibration-2026-04-25.md](docs/solutions/architecture-patterns/reuse-align-multires-for-geometry-calibration-2026-04-25.md)
+- Related learning: [docs/solutions/logic-errors/fista-square-artifacts-from-uncentered-lamino-projections-2026-04-29.md](docs/solutions/logic-errors/fista-square-artifacts-from-uncentered-lamino-projections-2026-04-29.md)
+- Related code: `src/tomojax/align/_config.py`
+- Related code: `src/tomojax/align/_setup_stage.py`
+- Related code: `src/tomojax/align/_pose_stage.py`
+- Related code: `src/tomojax/align/optimizers.py`
+- Related code: `scripts/real_laminography/run_real_lamino_native_setup_pose_256.py`

--- a/docs/solutions/architecture-patterns/alignment-early-stop-policy-profiles-2026-05-01.md
+++ b/docs/solutions/architecture-patterns/alignment-early-stop-policy-profiles-2026-05-01.md
@@ -1,0 +1,108 @@
+---
+title: Alignment Early Stop Policy Profiles
+date: 2026-05-01
+category: architecture-patterns
+module: TomoJAX alignment
+problem_type: architecture_pattern
+component: tooling
+severity: medium
+applies_when:
+  - "Changing alignment early stopping for setup geometry or pose stages"
+  - "Interpreting real-data laminography loss curves that move without visible preview changes"
+  - "Adding diagnostics to alignment stage summaries, checkpoints, or runner manifests"
+tags: [tomojax, alignment, early-stopping, validation-lm, diagnostics, real-data]
+---
+
+# Alignment Early Stop Policy Profiles
+
+## Context
+
+Alignment early stopping is part of the unified setup+pose alignment contract.
+It should not be a private runner heuristic, and it should not interpret every
+loss decrease the same way across setup geometry, pose cleanup, and final polish.
+
+The practical failure mode from the April 2026 real laminography runs was:
+
+```text
+total level loss keeps drifting down
+but accepted geometry updates are microscopic
+and previews show no meaningful change
+```
+
+For setup geometry stages, especially detector roll and late refreshes, comparing
+one outer iteration's `geometry_loss_after` to the next outer iteration's
+`geometry_loss_after` is misleading. That comparison includes reconstruction
+refresh drift. The meaningful setup evidence is the accepted validation-LM step
+within the same objective context:
+
+```text
+geometry_loss_before -> geometry_loss_after
+geometry_accepted
+geometry_step_norm
+optimizer_selected_scale
+optimizer_condition_number
+```
+
+## Policy Shape
+
+TomoJAX exposes two intended profiles:
+
+- `compute_saving`: the default. Stop marginal stages when accepted gain and
+  active-DOF movement are both too small for the configured patience.
+- `robust`: conservative opt-in. Use it for final real-data runs or cases where
+  a false stop is more expensive than extra GPU time.
+
+`--no-early-stop` still disables alignment early stopping entirely. Legacy
+threshold flags such as `--early-stop-rel` and `--early-stop-patience` remain
+valid and override the selected profile's gain/patience thresholds.
+
+## Setup Stages
+
+Setup geometry uses stopped train-fold reconstruction and validation-LM. The
+early-stop policy should treat accepted validation-LM step evidence as primary:
+
+- accepted relative improvement from `geometry_loss_before` to
+  `geometry_loss_after`,
+- whitened/native setup step size,
+- optimizer acceptance,
+- selected LM scale,
+- condition number.
+
+Cross-outer `geometry_loss_after` drift is useful telemetry. It can reveal
+reconstruction refresh effects or real loss movement, but it should not keep a
+stage alive by itself.
+
+## Pose Stages
+
+Pose stages still have a useful fixed-volume pre/post step loss contract, so
+same-outer `rel_impr` remains meaningful. The policy also checks active movement
+evidence:
+
+- rotation movement for `alpha`, `beta`, or `phi`,
+- translation movement for `dx` or `dz`,
+- optimizer acceptance where available.
+
+This makes light polish stages less likely to run full iteration budgets when
+both loss gain and active movement are tiny.
+
+## Monitoring Guidance
+
+When monitoring a real run, report the total loss, but do not stop there. Also
+report:
+
+- `accepted_rel_impr`,
+- `geometry_step_norm` or pose movement stats,
+- `optimizer_selected_scale`,
+- `optimizer_condition_number`,
+- `early_stop_profile`,
+- `early_stop_decision`,
+- `early_stop_reason`,
+- early-stop streak counters.
+
+This distinction matters because "loss still drifting" and "accepted geometry
+step is too small to matter" are different diagnoses.
+
+## Related
+
+- `docs/solutions/architecture-patterns/reuse-align-multires-for-geometry-calibration-2026-04-25.md`
+- `docs/brainstorms/geometry-calibration-solver-requirements.md`

--- a/docs/solutions/logic-errors/fista-square-artifacts-from-uncentered-lamino-projections-2026-04-29.md
+++ b/docs/solutions/logic-errors/fista-square-artifacts-from-uncentered-lamino-projections-2026-04-29.md
@@ -1,0 +1,158 @@
+---
+title: FISTA Square Artifacts From Uncentered Laminography Projections
+date: 2026-04-29
+category: logic-errors
+module: real-laminography-alignment
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "FISTA checkpoint slices show large square or blocky low-frequency artifacts"
+  - "Coarse pyramid z-stack previews look like repeated square fields rather than the TEM grid"
+  - "FBP baseline looks plausible while FISTA alignment previews regress badly"
+root_cause: config_error
+resolution_type: config_change
+severity: high
+tags: [fista-tv, laminography, preprocessing, background-correction, checkpoint-previews, real-data]
+---
+
+# FISTA Square Artifacts From Uncentered Laminography Projections
+
+## Problem
+
+A cropped real laminography TEM-grid run produced FISTA checkpoint previews with
+large square, blocky artifacts. The FBP baseline still showed the grid structure,
+so the first suspicion was that the preview renderer, slab z mapping, or checkpoint
+resampling was corrupting the images.
+
+The failing run used the correct centered slab geometry but launched FISTA/alignment
+with projection background correction disabled.
+
+## Symptoms
+
+- FISTA checkpoint slices showed a dominant square or box-like structure instead of
+  the TEM grid.
+- Level 4 z-stack tiles repeated the same coarse content across adjacent global-z
+  labels.
+- The baseline `00_baseline/orthos.png` looked plausible, while
+  `01_setup_geometry/01_cor/timeline_z/...` previews looked wrong.
+- The run was numerically alive: losses decreased and geometry estimates moved
+  gradually, so this was not an obvious optimizer crash or NaN failure.
+
+## What Didn't Work
+
+- Treating the issue as a slab-centering mistake did not explain the square artifact.
+  The corrected run manifest had `slab_center_global_z=148`,
+  `preview_global_z=148`, and `preview_local_z=48`, so the preview plane was centered.
+- Treating the issue as PNG display scaling was incomplete. A controlled render from
+  the raw checkpoint showed that level-native checkpoints were coarse
+  (`32x32x12` at level 8 and `64x64x24` at level 4), but the same low-frequency
+  square structure remained after proper linear upsampling.
+- Treating the repeated z-stack labels as the whole bug was also incomplete. Coarse
+  pyramid previews naturally repeat nearby global-z labels because several full-res
+  global z positions map to the same coarse slice. That explains some preview
+  blockiness, not the strong square DC artifact.
+
+## Solution
+
+Run real laminography FISTA/alignment on zero-centered projection residuals. For
+these cropped and flat/dark-corrected real datasets, keep edge-median subtraction
+enabled unless the input has explicitly been converted to a zero-background
+attenuation residual.
+
+Bad launch:
+
+```bash
+uv run python scripts/real_laminography/run_real_lamino_native_setup_pose_256.py \
+  --input data/cropped_lamino_256/k11-67208_tem_grid_highview_crop256_corrected_512views_runner.nxs \
+  --slab-center-z 148 \
+  --preview-z 148 \
+  --slab-nz 96 \
+  --projection-background none \
+  --no-recon-positivity
+```
+
+Corrected launch:
+
+```bash
+uv run python scripts/real_laminography/run_real_lamino_native_setup_pose_256.py \
+  --input data/cropped_lamino_256/k11-67208_tem_grid_highview_crop256_corrected_512views_runner.nxs \
+  --slab-center-z 148 \
+  --preview-z 148 \
+  --slab-nz 96 \
+  --projection-background edge_median \
+  --background-edge-px 16 \
+  --no-recon-positivity
+```
+
+The corrected run preserved the same centered slab and geometry convention but
+changed the projection preprocessing:
+
+```json
+{
+  "projection_preprocessing": {
+    "background_mode": "edge_median",
+    "background_edge_px": 16,
+    "alignment_and_fista_use": "background_corrected_projections"
+  }
+}
+```
+
+The important diagnostic is the manifest's working projection statistics. In the
+bad run, raw and working projections were identical, with view medians around
+`0.20-0.25`. In the corrected run, edge offsets around `0.20-0.25` were removed
+and working view medians were near zero:
+
+```json
+{
+  "working_projection_stats": {
+    "percentiles": [-0.085, -0.071, -0.057, -0.000086, 0.068, 0.078, 0.090],
+    "view_median_percentiles": [-0.0049, -0.0035, -0.00024, 0.0038, 0.0089]
+  }
+}
+```
+
+## Why This Works
+
+Flat/dark correction makes detector response comparable across views, but it does
+not guarantee that the data passed to iterative reconstruction is zero-centered.
+The real cropped 67208 projections still had a positive edge/DC offset. With
+`projection_background=none`, FISTA-TV treated that offset as object signal and
+reconstructed it as a smooth, low-frequency square volume. At coarse pyramid
+levels this appeared as a very obvious blocky square in checkpoint previews.
+
+`edge_median` estimates a per-view background level from detector edges and
+subtracts it before the alignment/FISTA path. That leaves the reconstruction
+objective dominated by sample contrast instead of detector/background offset.
+
+The baseline FBP can still look plausible because it is rendered from raw
+projections for comparison, while alignment/FISTA uses the working projection
+stack. This difference is intentional, but it means a plausible baseline does not
+prove the FISTA input is correctly centered.
+
+## Prevention
+
+- For real laminography FISTA/alignment runs, inspect both
+  `raw_projection_stats` and `working_projection_stats` in `run_manifest.json`
+  before trusting checkpoint previews.
+- Treat `projection_background=none` as unsafe for real cropped data unless a
+  separate preprocessing step proves the working projection medians are already
+  near zero.
+- Add a runner guard or warning when `projection_background=none` and per-view
+  medians are not near zero.
+- Keep in mind that coarse checkpoint previews are level-native. Level 8 previews
+  are expected to be blocky because the checkpoint volume is `32x32x12`; that is
+  separate from a square DC artifact.
+
+Concrete regression coverage should create a positive-offset projection stack,
+run the runner preprocessing path with `edge_median`, and assert that the
+manifested working view-median percentiles are near zero. A complementary test
+should verify that `projection_background=none` records unchanged working stats
+and emits a warning for real-data FISTA/alignment runs.
+
+## Related Issues
+
+- The corrected run used the same centered slab mapping:
+  `slab_center_global_z=148`, `preview_global_z=148`, `preview_local_z=48`.
+- The preview renderer also needs careful interpretation for pyramid checkpoints:
+  repeated global-z labels can occur when multiple full-resolution z positions map
+  to the same coarse checkpoint slice.

--- a/scripts/alignment_visuals.py
+++ b/scripts/alignment_visuals.py
@@ -30,6 +30,7 @@ class VisualProfile:
     levels: tuple[int, ...]
     outer_iters: int
     early_stop: bool
+    early_stop_profile: str = "compute_saving"
 
 
 @dataclass(frozen=True)
@@ -231,7 +232,7 @@ def diagnostics_panel(
         f"status: {status or 'control'}",
         f"span/views: {theta_span:g} deg / {profile.views}",
         f"levels: {' '.join(str(v) for v in profile.levels)}",
-        f"iters/early: {profile.outer_iters} / {profile.early_stop}",
+        f"iters/early: {profile.outer_iters} / {profile.early_stop} ({profile.early_stop_profile})",
         "",
         "hidden",
         f"det_u={hidden['det_u_px']:.3g} det_v={hidden['det_v_px']:.3g}",

--- a/scripts/generate_alignment_before_after_128.py
+++ b/scripts/generate_alignment_before_after_128.py
@@ -117,6 +117,7 @@ class RunProfile:
     views_per_batch: int
     gather_dtype: str
     early_stop: bool
+    early_stop_profile: str
     early_stop_rel_impr: float
     early_stop_patience: int
 
@@ -164,6 +165,7 @@ def docs_profile() -> RunProfile:
         views_per_batch=1,
         gather_dtype="bf16",
         early_stop=True,
+        early_stop_profile="compute_saving",
         early_stop_rel_impr=1e-3,
         early_stop_patience=2,
     )
@@ -181,6 +183,7 @@ def smoke_profile() -> RunProfile:
         views_per_batch=1,
         gather_dtype="fp32",
         early_stop=False,
+        early_stop_profile="compute_saving",
         early_stop_rel_impr=1e-3,
         early_stop_patience=2,
     )
@@ -278,6 +281,7 @@ def profile_from_args(args: argparse.Namespace) -> RunProfile:
         ),
         gather_dtype=str(args.gather_dtype or base.gather_dtype),
         early_stop=bool(args.early_stop if args.early_stop is not None else base.early_stop),
+        early_stop_profile=str(args.early_stop_profile or base.early_stop_profile),
         early_stop_rel_impr=float(
             args.early_stop_rel_impr
             if args.early_stop_rel_impr is not None
@@ -538,6 +542,7 @@ def _run_geometry_alignment(
             optimise_dofs=optimise_dofs,
             freeze_dofs=(),
             early_stop=bool(profile.early_stop),
+            early_stop_profile=str(profile.early_stop_profile),
             early_stop_rel_impr=float(profile.early_stop_rel_impr),
             early_stop_patience=int(profile.early_stop_patience),
             gather_dtype=profile.gather_dtype,
@@ -909,6 +914,7 @@ def _visual_profile(profile: RunProfile) -> VisualProfile:
         levels=tuple(int(v) for v in profile.levels),
         outer_iters=int(profile.outer_iters),
         early_stop=bool(profile.early_stop),
+        early_stop_profile=str(profile.early_stop_profile),
     )
 
 
@@ -1468,6 +1474,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     early_stop = parser.add_mutually_exclusive_group()
     early_stop.add_argument("--early-stop", dest="early_stop", action="store_true", default=None)
     early_stop.add_argument("--no-early-stop", dest="early_stop", action="store_false")
+    parser.add_argument("--early-stop-profile", default=None)
     parser.add_argument("--early-stop-rel-impr", type=float, default=None)
     parser.add_argument("--early-stop-patience", type=int, default=None)
     parser.add_argument("--gather-dtype", default=None, choices=["fp32", "bf16", "fp16"])

--- a/scripts/real_laminography/run_real_lamino_native_setup_pose_256.py
+++ b/scripts/real_laminography/run_real_lamino_native_setup_pose_256.py
@@ -34,6 +34,13 @@ from tomojax.align.geometry.geometry_blocks import (
     level_detector_grid,
 )
 from tomojax.align._setup_stage import _optimize_setup_geometry_bilevel_for_level
+from tomojax.align.early_stop import (
+    EarlyStopState,
+    annotate_stat_with_early_stop,
+    evaluate_early_stop,
+    resolve_early_stop_policy,
+    setup_evidence_from_stat,
+)
 from tomojax.align.pipeline import (
     AlignConfig,
     align,
@@ -545,6 +552,7 @@ def _make_cfg(
         recon_positivity=bool(args.recon_positivity),
         seed_translations=False,
         early_stop=bool(args.early_stop),
+        early_stop_profile=str(args.early_stop_profile),
         early_stop_rel_impr=float(args.early_stop_rel),
         early_stop_patience=int(args.early_stop_patience),
         log_summary=True,
@@ -658,8 +666,14 @@ def run_setup_stage(
             x_level = upsample_volume(jnp.asarray(x_init), prev_factor // factor, (g.nx, g.ny, g.nz))
         else:
             x_level = None
-        last_loss = math.inf
-        stale = 0
+        prev_loss_after: float | None = None
+        early_stop_state = EarlyStopState()
+        early_stop_policy = resolve_early_stop_policy(
+            enabled=bool(ctx.args.early_stop),
+            profile=str(ctx.args.early_stop_profile),
+            rel_impr_threshold=float(ctx.args.early_stop_rel),
+            patience=int(ctx.args.early_stop_patience),
+        )
         for outer in range(1, int(ctx.args.outer_iters) + 1):
             _status(
                 ctx.status_path,
@@ -716,6 +730,20 @@ def run_setup_stage(
                     "setup_bounds_clipped": clipped,
                 }
             )
+            evidence = setup_evidence_from_stat(
+                stat,
+                active_dofs=active_setup,
+                prev_loss_after=prev_loss_after,
+            )
+            decision = evaluate_early_stop(
+                evidence=evidence,
+                policy=early_stop_policy,
+                state=early_stop_state,
+                outer_idx=int(outer),
+            )
+            annotate_stat_with_early_stop(stat, decision)
+            early_stop_state = decision.state
+            prev_loss_after = evidence.loss_after
             stage_stats.append(stat)
             stem = f"outer_{len(stage_stats):03d}_level{factor:02d}_iter{outer:02d}"
             preview_dir = stage_dir / "timeline_z"
@@ -750,14 +778,19 @@ def run_setup_stage(
                 "geometry_status",
                 "optimizer_selected_scale",
                 "optimizer_condition_number",
+                "accepted_rel_impr",
+                "loss_drift_from_prev_after",
+                "early_stop_profile",
+                "early_stop_decision",
+                "early_stop_reason",
+                "early_stop_gain_streak",
+                "early_stop_step_streak",
+                "early_stop_rejected_streak",
+                "early_stop_unhealthy_streak",
                 "elapsed_seconds",
             ]
             _append_csv(stage_dir / "stage_summary.csv", stat, fields)
-            loss_after = float(stat.get("geometry_loss_after", last_loss))
-            rel = (last_loss - loss_after) / max(abs(last_loss), 1e-6) if math.isfinite(last_loss) else math.inf
-            stale = stale + 1 if rel < float(ctx.args.early_stop_rel) else 0
-            last_loss = loss_after
-            if bool(ctx.args.early_stop) and stale >= int(ctx.args.early_stop_patience):
+            if decision.should_stop:
                 break
         x_init = np.asarray(x_level, dtype=np.float32)
         prev_factor = int(factor)
@@ -1062,6 +1095,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--gn-damping", type=float, default=1e-3)
     parser.add_argument("--filter", dest="filter_name", default="ramp")
     parser.add_argument("--early-stop", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--early-stop-profile", default="compute_saving")
     parser.add_argument("--early-stop-rel", type=float, default=1e-3)
     parser.add_argument("--early-stop-patience", type=int, default=2)
     parser.add_argument("--snapshot-max-cols", type=int, default=6)
@@ -1184,6 +1218,7 @@ def main() -> int:
                 "pose_schedule": pose_schedule,
                 "early_stop": {
                     "enabled": bool(args.early_stop),
+                    "profile": str(args.early_stop_profile),
                     "rel_impr": float(args.early_stop_rel),
                     "patience": int(args.early_stop_patience),
                 },

--- a/src/tomojax/align/_config.py
+++ b/src/tomojax/align/_config.py
@@ -5,6 +5,7 @@ from typing import Literal, Mapping, TypeAlias, cast
 
 from ..core.geometry.base import Geometry
 from ..recon.types import Regulariser
+from .early_stop import EarlyStopProfile, normalize_early_stop_profile
 from .objectives.loss_specs import AlignmentLossConfig, L2OtsuLossSpec
 from .model.diagnostics import GaugePolicy
 from .model.dofs import (
@@ -154,6 +155,7 @@ class AlignConfig:
     recon_L: float | None = None
     # Early stopping across outers (alignment phase)
     early_stop: bool = True
+    early_stop_profile: EarlyStopProfile = "compute_saving"
     early_stop_rel_impr: float = 1e-3  # stop if (before-after)/before < this
     early_stop_patience: int = 2
     # Accept GN steps only when they improve the loss, up to gn_accept_tol.
@@ -235,6 +237,11 @@ class AlignConfig:
                 bounds_lower=bounds_lower,
                 bounds_upper=bounds_upper,
             )
+        self.early_stop_profile = normalize_early_stop_profile(self.early_stop_profile)
+        if float(self.early_stop_rel_impr) < 0.0:
+            raise ValueError("early_stop_rel_impr must be >= 0")
+        if int(self.early_stop_patience) < 1:
+            raise ValueError("early_stop_patience must be >= 1")
 
 
 

--- a/src/tomojax/align/_pose_stage.py
+++ b/src/tomojax/align/_pose_stage.py
@@ -39,6 +39,13 @@ from ._observer import (
 )
 from ._reconstruction_stage import _run_reconstruction_step
 from ._results import AlignCheckpointCallback, AlignInfo, AlignResumeState, _set_float_stat
+from .early_stop import (
+    EarlyStopState,
+    annotate_stat_with_early_stop,
+    evaluate_early_stop,
+    pose_evidence_from_stat,
+    resolve_early_stop_policy,
+)
 from .model.dofs import bounds_vectors
 from .model.gauge import (
     GaugeFixMode,
@@ -1464,6 +1471,17 @@ def align(
     # Reuse measured Lipschitz across outer iterations to avoid repeated power-method
     L_prev = resume_state.L if resume_state is not None else cfg.recon_L
     small_impr_streak = int(resume_state.small_impr_streak) if resume_state is not None else 0
+    early_stop_state = (
+        EarlyStopState.from_mapping(resume_state.early_stop_state)
+        if resume_state is not None
+        else EarlyStopState()
+    )
+    early_stop_policy = resolve_early_stop_policy(
+        enabled=bool(cfg.early_stop),
+        profile=getattr(cfg, "early_stop_profile", "compute_saving"),
+        rel_impr_threshold=float(cfg.early_stop_rel_impr),
+        patience=int(cfg.early_stop_patience),
+    )
     opt_mode = str(cfg.opt_method).lower()
     outer_stats: list[OuterStat] = (
         [dict(stat) for stat in resume_state.outer_stats] if resume_state is not None else []
@@ -1485,6 +1503,7 @@ def align(
                 outer_stats=[dict(stat) for stat in outer_stats],
                 L=(float(L_prev) if L_prev is not None else None),
                 small_impr_streak=int(small_impr_streak),
+                early_stop_state=early_stop_state.to_dict(),
                 elapsed_offset=float(time.perf_counter() - wall_start),
             )
         )
@@ -1561,6 +1580,19 @@ def align(
         )
         loss_hist.append(total_loss)
         stat.update(align_stat)
+        early_evidence = pose_evidence_from_stat(
+            stat,
+            active_dofs=tuple(motion_model.active_names),
+        )
+        early_decision = evaluate_early_stop(
+            evidence=early_evidence,
+            policy=early_stop_policy,
+            state=early_stop_state,
+            outer_idx=outer_idx,
+        )
+        annotate_stat_with_early_stop(stat, early_decision)
+        early_stop_state = early_decision.state
+        small_impr_streak = int(early_stop_state.gain_streak)
 
         outer_time = time.perf_counter() - outer_start
         stat["outer_time"] = outer_time
@@ -1579,28 +1611,19 @@ def align(
                 stopped_by_observer = observer_action == "stop_run"
                 should_break = True
 
-        # Early stopping based on alignment improvement during GN/GD step
-        if cfg.early_stop and (rel_impr is not None):
-            rel_for_patience = rel_impr
-            if (not math.isfinite(rel_for_patience)) or (rel_for_patience < 0.0):
-                rel_for_patience = 0.0
-            if rel_for_patience < float(cfg.early_stop_rel_impr):
-                small_impr_streak += 1
-            else:
-                small_impr_streak = 0
-            if small_impr_streak >= int(cfg.early_stop_patience):
-                if cfg.log_summary:
-                    logging.info(
-                        "Early stop after %d outer iters (%s elapsed): rel_impr=%.3e < %.3e for %d consecutive outers",
-                        outer_idx,
-                        format_duration(stat.get("cumulative_time")),
-                        float(rel_impr),
-                        float(cfg.early_stop_rel_impr),
-                        int(cfg.early_stop_patience),
-                    )
-                should_break = True
-        elif cfg.early_stop:
-            small_impr_streak = 0
+        if early_decision.should_stop:
+            if cfg.log_summary:
+                logging.info(
+                    "Early stop after %d outer iters (%s elapsed): %s "
+                    "(profile=%s, gain_streak=%d, step_streak=%d)",
+                    outer_idx,
+                    format_duration(stat.get("cumulative_time")),
+                    early_decision.reason,
+                    early_decision.policy.profile,
+                    early_decision.state.gain_streak,
+                    early_decision.state.step_streak,
+                )
+            should_break = True
 
         _emit_checkpoint_state()
         if should_break:
@@ -1674,6 +1697,7 @@ def align(
         else str(cfg.opt_method),
         "completed_outer_iters": len(outer_stats),
         "small_impr_streak": int(small_impr_streak),
+        "early_stop_state": early_stop_state.to_dict(),
         "motion_coeffs": motion_coeffs,
         "gauge_fix": constraint_ctx.gauge_fix,
         "gauge_fix_dofs": list(constraint_ctx.gauge_dofs),

--- a/src/tomojax/align/_pose_stage.py
+++ b/src/tomojax/align/_pose_stage.py
@@ -1472,7 +1472,10 @@ def align(
     L_prev = resume_state.L if resume_state is not None else cfg.recon_L
     small_impr_streak = int(resume_state.small_impr_streak) if resume_state is not None else 0
     early_stop_state = (
-        EarlyStopState.from_mapping(resume_state.early_stop_state)
+        EarlyStopState.from_resume(
+            resume_state.early_stop_state,
+            legacy_gain_streak=small_impr_streak,
+        )
         if resume_state is not None
         else EarlyStopState()
     )

--- a/src/tomojax/align/_results.py
+++ b/src/tomojax/align/_results.py
@@ -35,6 +35,7 @@ class AlignInfo(TypedDict):
     optimizer_kind: str
     completed_outer_iters: int
     small_impr_streak: int
+    early_stop_state: MetadataDict | None
     motion_coeffs: jnp.ndarray | None
     gauge_fix: str
     gauge_fix_dofs: list[str]
@@ -72,6 +73,7 @@ class AlignMultiresInfo(TypedDict):
     geometry_dofs: list[str]
     geometry_calibration_state: MetadataDict | None
     geometry_calibration_diagnostics: MetadataDict | None
+    early_stop_state: MetadataDict | None
 
 
 @dataclass
@@ -84,6 +86,7 @@ class AlignResumeState:
     outer_stats: list[OuterStat] = field(default_factory=list)
     L: float | None = None
     small_impr_streak: int = 0
+    early_stop_state: dict[str, object] = field(default_factory=dict)
     elapsed_offset: float = 0.0
 
 
@@ -101,6 +104,7 @@ class AlignMultiresResumeState:
     outer_stats: list[OuterStat] = field(default_factory=list)
     L: float | None = None
     small_impr_streak: int = 0
+    early_stop_state: dict[str, object] = field(default_factory=dict)
     elapsed_offset: float = 0.0
     level_complete: bool = False
     run_complete: bool = False

--- a/src/tomojax/align/_setup_stage.py
+++ b/src/tomojax/align/_setup_stage.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass
 from typing import Any, Iterable
 
@@ -19,6 +18,13 @@ from .geometry.geometry_applier import (
     materialize_setup_geometry,
 )
 from .objectives.loss_adapters import build_loss_adapter
+from .early_stop import (
+    EarlyStopState,
+    annotate_stat_with_early_stop,
+    evaluate_early_stop,
+    resolve_early_stop_policy,
+    setup_evidence_from_stat,
+)
 from .optimizers import ValidationLmConfig, run_active_validation_lm
 from .model.schedules import ResolvedAlignmentStage
 from .model.state import AlignmentState, PoseState, SetupGeometryState
@@ -377,7 +383,14 @@ def _optimize_setup_geometry_bilevel_for_level(
 
     setup_state = alignment_state
     setup_stats: list[OuterStat] = []
-    last_loss = math.inf
+    prev_loss_after: float | None = None
+    early_stop_state = EarlyStopState()
+    early_stop_policy = resolve_early_stop_policy(
+        enabled=bool(cfg.early_stop),
+        profile=getattr(cfg, "early_stop_profile", "compute_saving"),
+        rel_impr_threshold=float(cfg.early_stop_rel_impr),
+        patience=int(cfg.early_stop_patience),
+    )
     outer_limit = max(1, int(stage.maxiter if stage is not None else cfg.outer_iters))
     for outer_idx in range(1, outer_limit + 1):
         objective_result = _run_setup_validation_objective(
@@ -397,7 +410,6 @@ def _optimize_setup_geometry_bilevel_for_level(
         )
         opt_result = objective_result.opt_result
         setup_state = opt_result.state
-        last_loss = float(opt_result.loss)
         stat = _build_geometry_stage_stat(
             objective_result=objective_result,
             active_view=active_view,
@@ -410,12 +422,23 @@ def _optimize_setup_geometry_bilevel_for_level(
             outer_idx=outer_idx,
             init_x=init_x,
         )
+        evidence = setup_evidence_from_stat(
+            stat,
+            active_dofs=tuple(active_geometry_dofs),
+            prev_loss_after=prev_loss_after,
+        )
+        decision = evaluate_early_stop(
+            evidence=evidence,
+            policy=early_stop_policy,
+            state=early_stop_state,
+            outer_idx=outer_idx,
+        )
+        annotate_stat_with_early_stop(stat, decision)
+        early_stop_state = decision.state
+        prev_loss_after = evidence.loss_after
         setup_stats.append(stat)
-        if bool(cfg.early_stop) and outer_idx > 1:
-            prev = float(setup_stats[-2].get("geometry_loss_after", math.inf))
-            impr = (prev - last_loss) / max(abs(prev), 1e-6)
-            if impr < float(cfg.early_stop_rel_impr):
-                break
+        if decision.should_stop:
+            break
 
     x_next = _refresh_setup_reconstruction(
         geometry=geometry,

--- a/src/tomojax/align/_stage_loop.py
+++ b/src/tomojax/align/_stage_loop.py
@@ -183,6 +183,7 @@ class StageRuntime:
                     outer_stats=self.stats_before_level + self.level_stats + enriched_stats,
                     L=state.L,
                     small_impr_streak=int(state.small_impr_streak),
+                    early_stop_state=dict(state.early_stop_state),
                     elapsed_offset=float(self.global_elapsed_offset + state.elapsed_offset),
                     level_complete=False,
                     run_complete=False,
@@ -290,6 +291,7 @@ def _run_multires_level_stages(
         "active_dofs": [],
         "completed_outer_iters": 0,
         "small_impr_streak": 0,
+        "early_stop_state": {},
         "motion_coeffs": None,
         "gauge_fix": final_gauge_fix,
         "gauge_fix_dofs": final_gauge_fix_dofs,
@@ -396,6 +398,7 @@ def _run_multires_level_stages(
                 outer_stats=[dict(stat) for stat in level_resume.resume_stage_stats],
                 L=resume_state.L,
                 small_impr_streak=int(resume_state.small_impr_streak),
+                early_stop_state=dict(resume_state.early_stop_state),
                 elapsed_offset=float(resume_state.elapsed_offset - global_elapsed_offset),
             )
             stage_resume_consumed = True
@@ -590,6 +593,7 @@ def _build_multires_checkpoint_state(
     outer_stats: list[OuterStat],
     L: object,
     small_impr_streak: int,
+    early_stop_state: Mapping[str, object] | None,
     elapsed_offset: float,
     level_complete: bool,
     run_complete: bool,
@@ -612,6 +616,7 @@ def _build_multires_checkpoint_state(
         outer_stats=[dict(stat) for stat in outer_stats],
         L=L,
         small_impr_streak=int(small_impr_streak),
+        early_stop_state=dict(early_stop_state or {}),
         elapsed_offset=float(elapsed_offset),
         level_complete=bool(level_complete),
         run_complete=bool(run_complete),
@@ -666,6 +671,7 @@ def _emit_level_completion_checkpoint(
             outer_stats=[dict(stat) for stat in global_outer_stats],
             L=info.get("L"),
             small_impr_streak=int(info.get("small_impr_streak", 0)),
+            early_stop_state=dict(info.get("early_stop_state", {}) or {}),
             elapsed_offset=float(global_elapsed_offset),
             level_complete=level_complete,
             run_complete=False,
@@ -710,6 +716,7 @@ def _emit_run_completion_checkpoint(
             outer_stats=[dict(stat) for stat in global_outer_stats],
             L=None,
             small_impr_streak=0,
+            early_stop_state={},
             elapsed_offset=float(global_elapsed_offset),
             level_complete=True,
             run_complete=True,
@@ -763,6 +770,20 @@ def _final_align_multires_info(
         ),
         None,
     )
+    early_stop_state = next(
+        (
+            {
+                "gain_streak": stat.get("early_stop_gain_streak", 0),
+                "step_streak": stat.get("early_stop_step_streak", 0),
+                "rejected_streak": stat.get("early_stop_rejected_streak", 0),
+                "unhealthy_streak": stat.get("early_stop_unhealthy_streak", 0),
+                "nonfinite_streak": stat.get("early_stop_nonfinite_streak", 0),
+            }
+            for stat in reversed(global_outer_stats)
+            if isinstance(stat, Mapping) and stat.get("early_stop_profile") is not None
+        ),
+        {},
+    )
 
     return {
         "loss": loss_hist,
@@ -799,6 +820,7 @@ def _final_align_multires_info(
             else None
         ),
         "geometry_calibration_diagnostics": geometry_calibration_diagnostics,
+        "early_stop_state": early_stop_state,
     }
 
 

--- a/src/tomojax/align/early_stop.py
+++ b/src/tomojax/align/early_stop.py
@@ -73,6 +73,19 @@ class EarlyStopState:
             nonfinite_streak=_coerce_int(value.get("nonfinite_streak")),
         )
 
+    @classmethod
+    def from_resume(
+        cls,
+        value: Mapping[str, object] | None,
+        *,
+        legacy_gain_streak: int = 0,
+    ) -> "EarlyStopState":
+        """Restore early-stop state, preserving pre-structured checkpoint streaks."""
+
+        if value:
+            return cls.from_mapping(value)
+        return cls(gain_streak=max(0, int(legacy_gain_streak)))
+
     def to_dict(self) -> dict[str, int]:
         return asdict(self)
 

--- a/src/tomojax/align/early_stop.py
+++ b/src/tomojax/align/early_stop.py
@@ -1,0 +1,440 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import math
+from typing import Literal, Mapping, TypeAlias, cast
+
+from ._observer import OuterStat
+
+
+EarlyStopProfile: TypeAlias = Literal["compute_saving", "robust", "off"]
+EarlyStopStageKind: TypeAlias = Literal["setup", "pose"]
+
+
+@dataclass(frozen=True, slots=True)
+class EarlyStopPolicy:
+    """Resolved thresholds for one alignment early-stop profile."""
+
+    profile: EarlyStopProfile = "compute_saving"
+    enabled: bool = True
+    rel_impr_threshold: float = 1e-3
+    patience: int = 2
+    min_outer_iters: int = 2
+    setup_step_threshold: float = 2.5e-3
+    pose_rot_step_threshold: float = 1e-6
+    pose_trans_step_threshold: float = 1e-4
+    tiny_scale_threshold: float = 1e-6
+    max_condition_number: float = 1e12
+    stop_on_rejected: bool = True
+    stop_on_unhealthy_optimizer: bool = True
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class EarlyStopEvidence:
+    """Normalized evidence from one setup or pose outer iteration."""
+
+    stage_kind: EarlyStopStageKind
+    active_dofs: tuple[str, ...] = ()
+    rel_impr: float | None = None
+    accepted_rel_impr: float | None = None
+    loss_before: float | None = None
+    loss_after: float | None = None
+    accepted: bool | None = None
+    step_norm: float | None = None
+    rot_step: float | None = None
+    trans_step: float | None = None
+    selected_scale: float | None = None
+    condition_number: float | None = None
+    loss_drift_from_prev_after: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class EarlyStopState:
+    """Serializable state carried across outer iterations within one stage."""
+
+    gain_streak: int = 0
+    step_streak: int = 0
+    rejected_streak: int = 0
+    unhealthy_streak: int = 0
+    nonfinite_streak: int = 0
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object] | None) -> "EarlyStopState":
+        if not value:
+            return cls()
+        return cls(
+            gain_streak=_coerce_int(value.get("gain_streak")),
+            step_streak=_coerce_int(value.get("step_streak")),
+            rejected_streak=_coerce_int(value.get("rejected_streak")),
+            unhealthy_streak=_coerce_int(value.get("unhealthy_streak")),
+            nonfinite_streak=_coerce_int(value.get("nonfinite_streak")),
+        )
+
+    def to_dict(self) -> dict[str, int]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class EarlyStopDecision:
+    """Decision and updated state for one early-stop evaluation."""
+
+    should_stop: bool
+    reason: str
+    state: EarlyStopState
+    policy: EarlyStopPolicy
+    evidence: EarlyStopEvidence
+    gain_is_small: bool | None
+    step_is_small: bool | None
+    optimizer_is_unhealthy: bool
+    loss_is_nonfinite: bool
+
+    def telemetry(self) -> dict[str, object]:
+        evidence = self.evidence
+        return {
+            "early_stop_profile": self.policy.profile,
+            "early_stop_enabled": bool(self.policy.enabled),
+            "early_stop_decision": "stop" if self.should_stop else "continue",
+            "early_stop_reason": self.reason,
+            "early_stop_gain_streak": int(self.state.gain_streak),
+            "early_stop_step_streak": int(self.state.step_streak),
+            "early_stop_rejected_streak": int(self.state.rejected_streak),
+            "early_stop_unhealthy_streak": int(self.state.unhealthy_streak),
+            "early_stop_nonfinite_streak": int(self.state.nonfinite_streak),
+            "early_stop_rel_threshold": float(self.policy.rel_impr_threshold),
+            "early_stop_patience": int(self.policy.patience),
+            "early_stop_min_outer_iters": int(self.policy.min_outer_iters),
+            "early_stop_gain_is_small": self.gain_is_small,
+            "early_stop_step_is_small": self.step_is_small,
+            "early_stop_optimizer_unhealthy": bool(self.optimizer_is_unhealthy),
+            "early_stop_loss_nonfinite": bool(self.loss_is_nonfinite),
+            "accepted_rel_impr": evidence.accepted_rel_impr,
+            "loss_drift_from_prev_after": evidence.loss_drift_from_prev_after,
+        }
+
+
+def normalize_early_stop_profile(value: object) -> EarlyStopProfile:
+    raw = str(value if value is not None else "compute_saving").strip().lower().replace("-", "_")
+    if raw in {"default", "compute", "compute_saving", "compute_saver"}:
+        return "compute_saving"
+    if raw in {"robust", "conservative"}:
+        return "robust"
+    if raw in {"off", "disabled", "none", "false"}:
+        return "off"
+    raise ValueError("early_stop_profile must be one of 'compute_saving', 'robust', or 'off'")
+
+
+def resolve_early_stop_policy(
+    *,
+    enabled: bool,
+    profile: object = "compute_saving",
+    rel_impr_threshold: float = 1e-3,
+    patience: int = 2,
+) -> EarlyStopPolicy:
+    normalized = normalize_early_stop_profile(profile)
+    base_patience = max(1, int(patience))
+    rel = max(0.0, float(rel_impr_threshold))
+    if (not enabled) or normalized == "off":
+        return EarlyStopPolicy(
+            profile=normalized,
+            enabled=False,
+            rel_impr_threshold=rel,
+            patience=base_patience,
+        )
+    if normalized == "robust":
+        return EarlyStopPolicy(
+            profile="robust",
+            enabled=True,
+            rel_impr_threshold=rel,
+            patience=max(base_patience, 4),
+            min_outer_iters=max(2, min(3, max(base_patience, 4))),
+            setup_step_threshold=1e-3,
+            pose_rot_step_threshold=5e-7,
+            pose_trans_step_threshold=5e-5,
+            tiny_scale_threshold=1e-8,
+            max_condition_number=1e14,
+        )
+    return EarlyStopPolicy(
+        profile="compute_saving",
+        enabled=True,
+        rel_impr_threshold=rel,
+        patience=base_patience,
+        min_outer_iters=min(2, base_patience),
+        setup_step_threshold=2.5e-3,
+        pose_rot_step_threshold=1e-6,
+        pose_trans_step_threshold=1e-4,
+        tiny_scale_threshold=1e-6,
+        max_condition_number=1e12,
+    )
+
+
+def evaluate_early_stop(
+    *,
+    evidence: EarlyStopEvidence,
+    policy: EarlyStopPolicy,
+    state: EarlyStopState | Mapping[str, object] | None,
+    outer_idx: int,
+) -> EarlyStopDecision:
+    current = state if isinstance(state, EarlyStopState) else EarlyStopState.from_mapping(state)
+    if not policy.enabled:
+        return _decision(
+            False,
+            "disabled",
+            EarlyStopState(),
+            policy,
+            evidence,
+            gain_is_small=None,
+            step_is_small=None,
+            optimizer_is_unhealthy=False,
+            loss_is_nonfinite=False,
+        )
+
+    gain_value = evidence.accepted_rel_impr
+    if gain_value is None:
+        gain_value = evidence.rel_impr
+    loss_is_nonfinite = _is_nonfinite(gain_value) or _is_nonfinite(evidence.loss_after)
+    gain_is_small = None if gain_value is None or loss_is_nonfinite else gain_value < policy.rel_impr_threshold
+    step_is_small = _step_is_small(evidence, policy)
+    rejected = evidence.accepted is False
+    optimizer_is_unhealthy = _optimizer_is_unhealthy(evidence, policy)
+
+    next_state = EarlyStopState(
+        gain_streak=(current.gain_streak + 1 if gain_is_small is True else 0),
+        step_streak=(current.step_streak + 1 if step_is_small is True else 0),
+        rejected_streak=(current.rejected_streak + 1 if rejected else 0),
+        unhealthy_streak=(current.unhealthy_streak + 1 if optimizer_is_unhealthy else 0),
+        nonfinite_streak=(current.nonfinite_streak + 1 if loss_is_nonfinite else 0),
+    )
+
+    can_stop = int(outer_idx) >= int(policy.min_outer_iters)
+    reason = "warmup" if not can_stop else "continue"
+    should_stop = False
+    if can_stop and next_state.nonfinite_streak >= policy.patience:
+        should_stop = True
+        reason = "nonfinite_loss_or_gain"
+    elif (
+        can_stop
+        and policy.stop_on_rejected
+        and next_state.rejected_streak >= policy.patience
+    ):
+        should_stop = True
+        reason = "rejected_updates"
+    elif (
+        can_stop
+        and policy.stop_on_unhealthy_optimizer
+        and next_state.unhealthy_streak >= policy.patience
+    ):
+        should_stop = True
+        reason = "unhealthy_optimizer"
+    elif (
+        can_stop
+        and next_state.gain_streak >= policy.patience
+        and next_state.step_streak >= policy.patience
+    ):
+        should_stop = True
+        reason = "small_gain_and_step"
+
+    return _decision(
+        should_stop,
+        reason,
+        next_state,
+        policy,
+        evidence,
+        gain_is_small=gain_is_small,
+        step_is_small=step_is_small,
+        optimizer_is_unhealthy=optimizer_is_unhealthy,
+        loss_is_nonfinite=loss_is_nonfinite,
+    )
+
+
+def setup_evidence_from_stat(
+    stat: Mapping[str, object],
+    *,
+    active_dofs: tuple[str, ...] = (),
+    prev_loss_after: float | None = None,
+) -> EarlyStopEvidence:
+    loss_before = _coerce_float(stat.get("geometry_loss_before"))
+    loss_after = _coerce_float(stat.get("geometry_loss_after"))
+    accepted = _coerce_bool(stat.get("geometry_accepted"))
+    accepted_rel = _relative_improvement(loss_before, loss_after) if accepted else 0.0
+    drift = None
+    if prev_loss_after is not None and loss_after is not None and _finite(prev_loss_after):
+        drift = (float(prev_loss_after) - float(loss_after)) / max(abs(float(prev_loss_after)), 1e-12)
+    return EarlyStopEvidence(
+        stage_kind="setup",
+        active_dofs=active_dofs,
+        rel_impr=accepted_rel,
+        accepted_rel_impr=accepted_rel,
+        loss_before=loss_before,
+        loss_after=loss_after,
+        accepted=accepted,
+        step_norm=_coerce_float(
+            stat.get("geometry_step_norm", stat.get("step_norm_whitened"))
+        ),
+        selected_scale=_coerce_float(stat.get("optimizer_selected_scale")),
+        condition_number=_coerce_float(stat.get("optimizer_condition_number")),
+        loss_drift_from_prev_after=drift,
+    )
+
+
+def pose_evidence_from_stat(
+    stat: Mapping[str, object],
+    *,
+    active_dofs: tuple[str, ...] = (),
+) -> EarlyStopEvidence:
+    accepted = _pose_accepted(stat)
+    return EarlyStopEvidence(
+        stage_kind="pose",
+        active_dofs=active_dofs,
+        rel_impr=_coerce_float(stat.get("rel_impr")),
+        loss_before=_coerce_float(stat.get("loss_before")),
+        loss_after=_coerce_float(stat.get("loss_after")),
+        accepted=accepted,
+        rot_step=_first_float(stat, ("rot_rms", "rot_mean")),
+        trans_step=_first_float(stat, ("trans_rms", "trans_mean")),
+    )
+
+
+def annotate_stat_with_early_stop(stat: OuterStat, decision: EarlyStopDecision) -> None:
+    stat.update(cast(dict[str, object], decision.telemetry()))
+
+
+def _decision(
+    should_stop: bool,
+    reason: str,
+    state: EarlyStopState,
+    policy: EarlyStopPolicy,
+    evidence: EarlyStopEvidence,
+    *,
+    gain_is_small: bool | None,
+    step_is_small: bool | None,
+    optimizer_is_unhealthy: bool,
+    loss_is_nonfinite: bool,
+) -> EarlyStopDecision:
+    return EarlyStopDecision(
+        should_stop=bool(should_stop),
+        reason=str(reason),
+        state=state,
+        policy=policy,
+        evidence=evidence,
+        gain_is_small=gain_is_small,
+        step_is_small=step_is_small,
+        optimizer_is_unhealthy=bool(optimizer_is_unhealthy),
+        loss_is_nonfinite=bool(loss_is_nonfinite),
+    )
+
+
+def _step_is_small(evidence: EarlyStopEvidence, policy: EarlyStopPolicy) -> bool | None:
+    if evidence.stage_kind == "setup":
+        if evidence.step_norm is None or not _finite(evidence.step_norm):
+            return None
+        return abs(float(evidence.step_norm)) <= policy.setup_step_threshold
+
+    active = set(evidence.active_dofs)
+    checks: list[bool] = []
+    if active.intersection({"alpha", "beta", "phi"}):
+        if evidence.rot_step is not None and _finite(evidence.rot_step):
+            checks.append(abs(float(evidence.rot_step)) <= policy.pose_rot_step_threshold)
+    if active.intersection({"dx", "dz"}):
+        if evidence.trans_step is not None and _finite(evidence.trans_step):
+            checks.append(abs(float(evidence.trans_step)) <= policy.pose_trans_step_threshold)
+    if not active:
+        if evidence.rot_step is not None and _finite(evidence.rot_step):
+            checks.append(abs(float(evidence.rot_step)) <= policy.pose_rot_step_threshold)
+        if evidence.trans_step is not None and _finite(evidence.trans_step):
+            checks.append(abs(float(evidence.trans_step)) <= policy.pose_trans_step_threshold)
+    if not checks:
+        return True if evidence.accepted is False else None
+    return all(checks)
+
+
+def _optimizer_is_unhealthy(evidence: EarlyStopEvidence, policy: EarlyStopPolicy) -> bool:
+    if evidence.selected_scale is not None and _finite(evidence.selected_scale):
+        if abs(float(evidence.selected_scale)) <= policy.tiny_scale_threshold:
+            return True
+    if evidence.condition_number is not None:
+        if (not _finite(evidence.condition_number)) or (
+            float(evidence.condition_number) >= policy.max_condition_number
+        ):
+            return True
+    return False
+
+
+def _pose_accepted(stat: Mapping[str, object]) -> bool | None:
+    if "optimizer_accepted" in stat:
+        return _coerce_bool(stat.get("optimizer_accepted"))
+    if "lbfgs_accepted" in stat:
+        return _coerce_bool(stat.get("lbfgs_accepted"))
+    loss_before = _coerce_float(stat.get("loss_before"))
+    loss_after = _coerce_float(stat.get("loss_after"))
+    if loss_before is None or loss_after is None:
+        return None
+    return bool(loss_after <= loss_before)
+
+
+def _relative_improvement(before: float | None, after: float | None) -> float | None:
+    if before is None or after is None or not (_finite(before) and _finite(after)):
+        return None
+    return (float(before) - float(after)) / max(abs(float(before)), 1e-12)
+
+
+def _first_float(stat: Mapping[str, object], keys: tuple[str, ...]) -> float | None:
+    for key in keys:
+        value = _coerce_float(stat.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def _coerce_float(value: object) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+def _coerce_int(value: object) -> int:
+    try:
+        return max(0, int(value))  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0
+
+
+def _coerce_bool(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return None
+    raw = str(value).strip().lower()
+    if raw in {"1", "true", "yes", "y"}:
+        return True
+    if raw in {"0", "false", "no", "n"}:
+        return False
+    return None
+
+
+def _is_nonfinite(value: float | None) -> bool:
+    return value is not None and not _finite(value)
+
+
+def _finite(value: float | None) -> bool:
+    return value is not None and math.isfinite(float(value))
+
+
+__all__ = [
+    "EarlyStopDecision",
+    "EarlyStopEvidence",
+    "EarlyStopPolicy",
+    "EarlyStopProfile",
+    "EarlyStopState",
+    "annotate_stat_with_early_stop",
+    "evaluate_early_stop",
+    "normalize_early_stop_profile",
+    "pose_evidence_from_stat",
+    "resolve_early_stop_policy",
+    "setup_evidence_from_stat",
+]

--- a/src/tomojax/align/geometry/geometry_blocks.py
+++ b/src/tomojax/align/geometry/geometry_blocks.py
@@ -329,6 +329,9 @@ def summarize_geometry_calibration_stats(
                 "loss_before": loss_before,
                 "loss_after": loss_after,
                 "loss_drop": loss_drop,
+                "early_stop_profile": last.get("early_stop_profile"),
+                "early_stop_decision": last.get("early_stop_decision"),
+                "early_stop_reason": last.get("early_stop_reason"),
                 "status": status,
             }
         )

--- a/src/tomojax/align/io/checkpoint.py
+++ b/src/tomojax/align/io/checkpoint.py
@@ -27,6 +27,7 @@ _ALIGN_CONFIG_COMPAT_DEFAULTS = {
     "schedule": None,
     "gauge_policy": "reject",
     "gauge_priors": None,
+    "early_stop_profile": "compute_saving",
 }
 _ALIGN_CLI_COMPAT_DEFAULTS = {
     "recon_algo": "fista",
@@ -37,6 +38,7 @@ _ALIGN_CLI_COMPAT_DEFAULTS = {
     "gauge_policy": "reject",
     "optimise_dofs": [],
     "freeze_dofs": [],
+    "early_stop_profile": "compute_saving",
 }
 
 
@@ -67,6 +69,7 @@ class CheckpointMetadata(TypedDict, total=False):
     prev_factor: int | None
     L_prev: float | None
     small_impr_streak: int
+    early_stop_state: dict[str, Any]
     elapsed_offset: float
     config: Required[Any]
     cli_options: Required[dict[str, Any]]
@@ -117,6 +120,7 @@ class AlignmentCheckpointProgress:
     current_inner_iteration: int = 0
     L_prev: float | None = None
     small_impr_streak: int = 0
+    early_stop_state: Mapping[str, Any] | None = None
     elapsed_offset: float = 0.0
     level_complete: bool = False
     run_complete: bool = False
@@ -203,6 +207,7 @@ def build_alignment_checkpoint_metadata_from_input(
         "prev_factor": None if progress.prev_factor is None else int(progress.prev_factor),
         "L_prev": None if progress.L_prev is None else float(progress.L_prev),
         "small_impr_streak": int(progress.small_impr_streak),
+        "early_stop_state": _normalize_json_object(progress.early_stop_state),
         "elapsed_offset": float(progress.elapsed_offset),
         "config": normalize_json(metadata_input.config),
         "cli_options": _normalize_json_object(metadata_input.cli_options),
@@ -239,6 +244,7 @@ def build_alignment_checkpoint_metadata(
     current_inner_iteration: int = 0,
     L_prev: float | None = None,
     small_impr_streak: int = 0,
+    early_stop_state: Mapping[str, Any] | None = None,
     elapsed_offset: float = 0.0,
     random_state: Mapping[str, Any] | None = None,
     schedule_metadata: Mapping[str, Any] | None = None,
@@ -273,6 +279,7 @@ def build_alignment_checkpoint_metadata(
                 current_inner_iteration=current_inner_iteration,
                 L_prev=L_prev,
                 small_impr_streak=small_impr_streak,
+                early_stop_state=early_stop_state,
                 elapsed_offset=elapsed_offset,
                 level_complete=level_complete,
                 run_complete=run_complete,

--- a/src/tomojax/cli/align.py
+++ b/src/tomojax/cli/align.py
@@ -521,6 +521,11 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Relative improvement threshold for early stop (default 1e-3)",
     )
     p.add_argument(
+        "--early-stop-profile",
+        default="compute_saving",
+        help="Early-stop policy profile: compute_saving (default), robust, or off",
+    )
+    p.add_argument(
         "--early-stop-patience",
         type=int,
         default=None,
@@ -608,6 +613,7 @@ def _checkpoint_cli_options(args: argparse.Namespace, *, gather_dtype: str) -> d
         "optimise_dofs": list(args.optimise_dofs or []),
         "freeze_dofs": list(args.freeze_dofs or []),
         "schedule": args.schedule,
+        "early_stop_profile": str(args.early_stop_profile),
     }
 
 
@@ -630,6 +636,7 @@ def _checkpoint_metadata(
     prev_factor: int | None,
     L_prev: float | None,
     small_impr_streak: int,
+    early_stop_state: dict[str, object] | None,
     elapsed_offset: float,
     level_complete: bool,
     run_complete: bool,
@@ -664,6 +671,7 @@ def _checkpoint_metadata(
                 current_inner_iteration=0,
                 L_prev=L_prev,
                 small_impr_streak=small_impr_streak,
+                early_stop_state=early_stop_state,
                 elapsed_offset=elapsed_offset,
                 level_complete=level_complete,
                 run_complete=run_complete,
@@ -714,6 +722,7 @@ def _resume_state_from_checkpoint(
             outer_stats=[dict(stat) for stat in checkpoint.outer_stats],
             L=metadata.get("L_prev"),
             small_impr_streak=int(metadata.get("small_impr_streak", 0)),
+            early_stop_state=dict(metadata.get("early_stop_state", {}) or {}),
             elapsed_offset=float(metadata.get("elapsed_offset", 0.0)),
             level_complete=bool(metadata.get("level_complete", False)),
             run_complete=bool(metadata.get("run_complete", False)),
@@ -746,6 +755,7 @@ def _resume_state_from_checkpoint(
         outer_stats=[dict(stat) for stat in checkpoint.outer_stats],
         L=metadata.get("L_prev"),
         small_impr_streak=int(metadata.get("small_impr_streak", 0)),
+        early_stop_state=dict(metadata.get("early_stop_state", {}) or {}),
         elapsed_offset=float(metadata.get("elapsed_offset", 0.0)),
     )
 
@@ -876,6 +886,7 @@ def _build_align_cli_run_plan(
         log_compact=bool(args.log_compact),
         recon_L=(float(args.recon_L) if args.recon_L is not None else None),
         early_stop=bool(args.early_stop),
+        early_stop_profile=str(args.early_stop_profile),
         early_stop_rel_impr=(
             float(args.early_stop_rel) if args.early_stop_rel is not None else 1e-3
         ),
@@ -927,6 +938,7 @@ def _build_align_cli_run_plan(
         prev_factor=None,
         L_prev=None,
         small_impr_streak=0,
+        early_stop_state={},
         elapsed_offset=0.0,
         level_complete=False,
         run_complete=False,
@@ -1015,6 +1027,7 @@ def _make_align_cli_checkpoint_callbacks(plan: AlignCliRunPlan) -> AlignCliCheck
             prev_factor=None,
             L_prev=state.L,
             small_impr_streak=int(state.small_impr_streak),
+            early_stop_state=dict(state.early_stop_state),
             elapsed_offset=float(state.elapsed_offset),
             level_complete=run_complete or completed >= int(plan.cfg.outer_iters),
             run_complete=run_complete,
@@ -1065,6 +1078,7 @@ def _make_align_cli_checkpoint_callbacks(plan: AlignCliRunPlan) -> AlignCliCheck
             prev_factor=state.prev_factor,
             L_prev=state.L,
             small_impr_streak=int(state.small_impr_streak),
+            early_stop_state=dict(state.early_stop_state),
             elapsed_offset=float(state.elapsed_offset),
             level_complete=bool(state.level_complete),
             run_complete=bool(state.run_complete),
@@ -1153,6 +1167,7 @@ def _execute_alignment_plan(
                 outer_stats=[dict(stat) for stat in info_dict.get("outer_stats", [])],
                 L=info_dict.get("L"),
                 small_impr_streak=int(info_dict.get("small_impr_streak", 0)),
+                early_stop_state=dict(info_dict.get("early_stop_state", {}) or {}),
                 elapsed_offset=float(info_dict.get("wall_time_total", 0.0)),
             ),
             run_complete=True,

--- a/src/tomojax/cli/align.py
+++ b/src/tomojax/cli/align.py
@@ -16,6 +16,7 @@ from ..align.model.dofs import (
     normalize_alignment_dofs,
     normalize_bounds,
 )
+from ..align.early_stop import normalize_early_stop_profile
 from ..align.objectives.loss_specs import (
     AlignmentLossConfig,
     parse_loss_schedule,
@@ -613,7 +614,7 @@ def _checkpoint_cli_options(args: argparse.Namespace, *, gather_dtype: str) -> d
         "optimise_dofs": list(args.optimise_dofs or []),
         "freeze_dofs": list(args.freeze_dofs or []),
         "schedule": args.schedule,
-        "early_stop_profile": str(args.early_stop_profile),
+        "early_stop_profile": normalize_early_stop_profile(args.early_stop_profile),
     }
 
 

--- a/tests/test_align_checkpoint.py
+++ b/tests/test_align_checkpoint.py
@@ -48,6 +48,7 @@ def _metadata(
     prev_factor: int | None = None,
     L_prev: float | None = None,
     small_impr_streak: int = 0,
+    early_stop_state: dict[str, object] | None = None,
     elapsed_offset: float = 0.0,
     level_complete: bool = False,
     run_complete: bool = False,
@@ -77,6 +78,7 @@ def _metadata(
                 prev_factor=prev_factor,
                 L_prev=L_prev,
                 small_impr_streak=small_impr_streak,
+                early_stop_state=early_stop_state,
                 elapsed_offset=elapsed_offset,
                 level_complete=level_complete,
                 run_complete=run_complete,
@@ -119,6 +121,7 @@ def _resume_single_from_checkpoint(
         outer_stats=[dict(stat) for stat in checkpoint.outer_stats],
         L=meta.get("L_prev"),
         small_impr_streak=int(meta.get("small_impr_streak", 0)),
+        early_stop_state=dict(meta.get("early_stop_state", {}) or {}),
         elapsed_offset=float(meta.get("elapsed_offset", 0.0)),
     )
 
@@ -147,6 +150,7 @@ def _resume_multires_from_checkpoint(
         outer_stats=[dict(stat) for stat in checkpoint.outer_stats],
         L=meta.get("L_prev"),
         small_impr_streak=int(meta.get("small_impr_streak", 0)),
+        early_stop_state=dict(meta.get("early_stop_state", {}) or {}),
         elapsed_offset=float(meta.get("elapsed_offset", 0.0)),
         level_complete=bool(meta.get("level_complete", False)),
         run_complete=bool(meta.get("run_complete", False)),
@@ -236,6 +240,41 @@ def test_alignment_checkpoint_round_trips_arrays_and_metadata(tmp_path):
     assert checkpoint.loss_history == [3.0, 2.0]
     assert checkpoint.outer_stats[0]["outer_idx"] == 1
     assert checkpoint.metadata["completed_outer_iters_in_level"] == 1
+    assert checkpoint.metadata["early_stop_state"] == {}
+
+
+def test_alignment_checkpoint_round_trips_early_stop_state(tmp_path):
+    grid = Grid(nx=3, ny=3, nz=2, vx=1.0, vy=1.0, vz=1.0)
+    detector = Detector(nu=3, nv=2, du=1.0, dv=1.0)
+    projections = jnp.zeros((4, 2, 3), dtype=jnp.float32)
+    cfg = AlignConfig(outer_iters=2, recon_iters=1)
+    early_stop_state = {"gain_streak": 2, "step_streak": 1, "rejected_streak": 0}
+    metadata = _metadata(
+        cfg=cfg,
+        grid=grid,
+        detector=detector,
+        projections=projections,
+        completed_outer_iters_in_level=1,
+        global_outer_iters_completed=1,
+        early_stop_state=early_stop_state,
+    )
+
+    path = tmp_path / "align_checkpoint.npz"
+    save_alignment_checkpoint(
+        path,
+        x=np.ones((3, 3, 2), dtype=np.float32),
+        params5=np.zeros((4, 5), dtype=np.float32),
+        loss_history=[3.0],
+        outer_stats=[{"outer_idx": 1}],
+        metadata=metadata,
+    )
+
+    checkpoint = load_alignment_checkpoint(path)
+    validate_alignment_checkpoint(checkpoint, metadata)
+    resumed = _resume_single_from_checkpoint(path, metadata)
+
+    assert checkpoint.metadata["early_stop_state"] == early_stop_state
+    assert resumed.early_stop_state == early_stop_state
 
 
 def test_alignment_checkpoint_records_optional_schedule_metadata(tmp_path):

--- a/tests/test_align_contracts.py
+++ b/tests/test_align_contracts.py
@@ -8,6 +8,7 @@ import pytest
 
 from tomojax.align.objectives.loss_adapters import build_loss_adapter
 from tomojax.align.objectives.loss_specs import parse_loss_spec
+from tomojax.align.pipeline import AlignConfig
 from tomojax.core.geometry import Detector, Grid, ParallelGeometry
 
 
@@ -42,6 +43,19 @@ def test_pipeline_compatibility_symbols_remain_importable(symbol: str) -> None:
     pipeline = importlib.import_module("tomojax.align.pipeline")
 
     assert hasattr(pipeline, symbol)
+
+
+def test_align_config_normalizes_early_stop_profile_aliases() -> None:
+    cfg = AlignConfig(early_stop_profile="compute-saving")
+    robust = AlignConfig(early_stop_profile="conservative")
+
+    assert cfg.early_stop_profile == "compute_saving"
+    assert robust.early_stop_profile == "robust"
+
+
+def test_align_config_rejects_invalid_early_stop_profile() -> None:
+    with pytest.raises(ValueError, match="early_stop_profile"):
+        AlignConfig(early_stop_profile="forever")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_align_contracts.py
+++ b/tests/test_align_contracts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+from types import SimpleNamespace
 
 import jax.numpy as jnp
 import numpy as np
@@ -9,6 +10,7 @@ import pytest
 from tomojax.align.objectives.loss_adapters import build_loss_adapter
 from tomojax.align.objectives.loss_specs import parse_loss_spec
 from tomojax.align.pipeline import AlignConfig
+from tomojax.cli.align import _checkpoint_cli_options
 from tomojax.core.geometry import Detector, Grid, ParallelGeometry
 
 
@@ -56,6 +58,30 @@ def test_align_config_normalizes_early_stop_profile_aliases() -> None:
 def test_align_config_rejects_invalid_early_stop_profile() -> None:
     with pytest.raises(ValueError, match="early_stop_profile"):
         AlignConfig(early_stop_profile="forever")
+
+
+def test_checkpoint_cli_options_canonicalize_early_stop_profile_alias() -> None:
+    args = SimpleNamespace(
+        roi="auto",
+        grid=None,
+        gather_dtype="auto",
+        recon_algo="fista-tv",
+        views_per_batch=8,
+        spdhg_seed=0,
+        recon_positivity=False,
+        checkpoint_projector=False,
+        mask_vol="off",
+        gauge_fix="auto",
+        gauge_policy="stage",
+        optimise_dofs=["dx", "dz"],
+        freeze_dofs=[],
+        schedule="pose",
+        early_stop_profile="compute-saving",
+    )
+
+    options = _checkpoint_cli_options(args, gather_dtype="float32")
+
+    assert options["early_stop_profile"] == "compute_saving"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_align_early_stop.py
+++ b/tests/test_align_early_stop.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import math
+
+import jax.numpy as jnp
+
+from tomojax.align.early_stop import (
+    EarlyStopState,
+    evaluate_early_stop,
+    normalize_early_stop_profile,
+    pose_evidence_from_stat,
+    resolve_early_stop_policy,
+    setup_evidence_from_stat,
+)
+from tomojax.align.pipeline import AlignConfig, align
+from tomojax.core.geometry import Detector, Grid, ParallelGeometry
+
+
+def test_compute_saving_setup_continues_for_meaningful_accepted_step():
+    policy = resolve_early_stop_policy(
+        enabled=True,
+        profile="compute_saving",
+        rel_impr_threshold=1e-3,
+        patience=2,
+    )
+    evidence = setup_evidence_from_stat(
+        {
+            "geometry_loss_before": 100.0,
+            "geometry_loss_after": 99.0,
+            "geometry_accepted": True,
+            "geometry_step_norm": 0.02,
+            "optimizer_selected_scale": 1.0,
+            "optimizer_condition_number": 10.0,
+        },
+        active_dofs=("det_u_px",),
+    )
+
+    decision = evaluate_early_stop(
+        evidence=evidence,
+        policy=policy,
+        state=EarlyStopState(),
+        outer_idx=1,
+    )
+
+    assert decision.should_stop is False
+    assert decision.reason == "warmup"
+    assert decision.state.gain_streak == 0
+    assert decision.state.step_streak == 0
+    assert decision.telemetry()["accepted_rel_impr"] == 0.01
+
+
+def test_compute_saving_stops_tiny_accepted_setup_gain_and_step_despite_loss_drift():
+    policy = resolve_early_stop_policy(
+        enabled=True,
+        profile="compute_saving",
+        rel_impr_threshold=1e-3,
+        patience=2,
+    )
+    state = EarlyStopState()
+    prev_after = 100.0
+    for outer_idx, loss_before, loss_after in (
+        (1, 100.0, 99.999),
+        (2, 99.0, 98.9995),
+    ):
+        evidence = setup_evidence_from_stat(
+            {
+                "geometry_loss_before": loss_before,
+                "geometry_loss_after": loss_after,
+                "geometry_accepted": True,
+                "geometry_step_norm": 1e-4,
+                "optimizer_selected_scale": 1.0,
+                "optimizer_condition_number": 10.0,
+            },
+            active_dofs=("detector_roll_deg",),
+            prev_loss_after=prev_after,
+        )
+        decision = evaluate_early_stop(
+            evidence=evidence,
+            policy=policy,
+            state=state,
+            outer_idx=outer_idx,
+        )
+        state = decision.state
+        prev_after = float(loss_after)
+
+    assert decision.should_stop is True
+    assert decision.reason == "small_gain_and_step"
+    assert decision.state.gain_streak == 2
+    assert decision.state.step_streak == 2
+    assert decision.evidence.loss_drift_from_prev_after is not None
+
+
+def test_robust_profile_waits_longer_than_compute_saving_on_same_setup_evidence():
+    compute_policy = resolve_early_stop_policy(
+        enabled=True,
+        profile="compute_saving",
+        rel_impr_threshold=1e-3,
+        patience=2,
+    )
+    robust_policy = resolve_early_stop_policy(
+        enabled=True,
+        profile="robust",
+        rel_impr_threshold=1e-3,
+        patience=2,
+    )
+    evidence = setup_evidence_from_stat(
+        {
+            "geometry_loss_before": 100.0,
+            "geometry_loss_after": 99.999,
+            "geometry_accepted": True,
+            "geometry_step_norm": 1e-4,
+            "optimizer_selected_scale": 1.0,
+            "optimizer_condition_number": 10.0,
+        },
+        active_dofs=("detector_roll_deg",),
+    )
+
+    compute_state = EarlyStopState()
+    robust_state = EarlyStopState()
+    for outer_idx in range(1, 3):
+        compute_decision = evaluate_early_stop(
+            evidence=evidence,
+            policy=compute_policy,
+            state=compute_state,
+            outer_idx=outer_idx,
+        )
+        robust_decision = evaluate_early_stop(
+            evidence=evidence,
+            policy=robust_policy,
+            state=robust_state,
+            outer_idx=outer_idx,
+        )
+        compute_state = compute_decision.state
+        robust_state = robust_decision.state
+
+    assert compute_decision.should_stop is True
+    assert robust_decision.should_stop is False
+    assert robust_policy.patience == 4
+
+
+def test_rejected_setup_updates_stop_with_specific_reason():
+    policy = resolve_early_stop_policy(
+        enabled=True,
+        profile="compute_saving",
+        rel_impr_threshold=1e-3,
+        patience=2,
+    )
+    state = EarlyStopState()
+    evidence = setup_evidence_from_stat(
+        {
+            "geometry_loss_before": 100.0,
+            "geometry_loss_after": 100.0,
+            "geometry_accepted": False,
+            "geometry_step_norm": 0.0,
+            "optimizer_selected_scale": 0.0,
+            "optimizer_condition_number": 10.0,
+        },
+        active_dofs=("detector_roll_deg",),
+    )
+
+    for outer_idx in range(1, 3):
+        decision = evaluate_early_stop(
+            evidence=evidence,
+            policy=policy,
+            state=state,
+            outer_idx=outer_idx,
+        )
+        state = decision.state
+
+    assert decision.should_stop is True
+    assert decision.reason == "rejected_updates"
+    assert decision.state.rejected_streak == 2
+
+
+def test_missing_optional_evidence_does_not_crash_and_records_unknown_step():
+    policy = resolve_early_stop_policy(
+        enabled=True,
+        profile="compute_saving",
+        rel_impr_threshold=1e-3,
+        patience=2,
+    )
+    evidence = setup_evidence_from_stat(
+        {
+            "geometry_loss_before": 100.0,
+            "geometry_loss_after": 99.999,
+            "geometry_accepted": True,
+        },
+        active_dofs=("det_u_px",),
+    )
+
+    decision = evaluate_early_stop(
+        evidence=evidence,
+        policy=policy,
+        state={},
+        outer_idx=2,
+    )
+
+    assert decision.should_stop is False
+    assert decision.step_is_small is None
+    assert decision.telemetry()["early_stop_step_is_small"] is None
+
+
+def test_disabled_profile_never_stops():
+    policy = resolve_early_stop_policy(
+        enabled=True,
+        profile="off",
+        rel_impr_threshold=1e-3,
+        patience=1,
+    )
+    evidence = setup_evidence_from_stat(
+        {
+            "geometry_loss_before": 100.0,
+            "geometry_loss_after": math.inf,
+            "geometry_accepted": False,
+            "geometry_step_norm": 0.0,
+        },
+        active_dofs=("det_u_px",),
+    )
+
+    decision = evaluate_early_stop(
+        evidence=evidence,
+        policy=policy,
+        state=EarlyStopState(nonfinite_streak=10),
+        outer_idx=10,
+    )
+
+    assert decision.should_stop is False
+    assert decision.reason == "disabled"
+    assert decision.state == EarlyStopState()
+
+
+def test_pose_translation_only_uses_translation_movement_evidence():
+    policy = resolve_early_stop_policy(
+        enabled=True,
+        profile="compute_saving",
+        rel_impr_threshold=1e-3,
+        patience=2,
+    )
+    state = EarlyStopState()
+    evidence = pose_evidence_from_stat(
+        {
+            "loss_before": 50.0,
+            "loss_after": 49.999,
+            "rel_impr": 2e-5,
+            "trans_mean": 1e-6,
+        },
+        active_dofs=("dx", "dz"),
+    )
+
+    for outer_idx in range(1, 3):
+        decision = evaluate_early_stop(
+            evidence=evidence,
+            policy=policy,
+            state=state,
+            outer_idx=outer_idx,
+        )
+        state = decision.state
+
+    assert decision.should_stop is True
+    assert decision.reason == "small_gain_and_step"
+    assert decision.step_is_small is True
+
+
+def test_profile_aliases_normalize():
+    assert normalize_early_stop_profile("compute-saving") == "compute_saving"
+    assert normalize_early_stop_profile("conservative") == "robust"
+    assert normalize_early_stop_profile("disabled") == "off"
+
+
+def test_pose_alignment_emits_early_stop_telemetry_on_outer_stats():
+    grid = Grid(nx=4, ny=4, nz=4, vx=1.0, vy=1.0, vz=1.0)
+    detector = Detector(nu=4, nv=4, du=1.0, dv=1.0)
+    geometry = ParallelGeometry(
+        grid=grid,
+        detector=detector,
+        thetas_deg=jnp.linspace(0.0, 180.0, 4, endpoint=False),
+    )
+    projections = jnp.zeros((4, 4, 4), dtype=jnp.float32)
+
+    _x, _params, info = align(
+        geometry,
+        grid,
+        detector,
+        projections,
+        cfg=AlignConfig(
+            outer_iters=2,
+            recon_iters=1,
+            tv_prox_iters=1,
+            optimise_dofs=("dx", "dz"),
+            early_stop=True,
+            early_stop_profile="compute_saving",
+            views_per_batch=1,
+            checkpoint_projector=False,
+            gather_dtype="fp32",
+            recon_positivity=False,
+        ),
+    )
+
+    assert info["outer_stats"]
+    assert info["outer_stats"][-1]["early_stop_profile"] == "compute_saving"
+    assert info["outer_stats"][-1]["early_stop_decision"] in {"continue", "stop"}
+    assert "early_stop_state" in info

--- a/tests/test_align_early_stop.py
+++ b/tests/test_align_early_stop.py
@@ -49,6 +49,25 @@ def test_compute_saving_setup_continues_for_meaningful_accepted_step():
     assert decision.telemetry()["accepted_rel_impr"] == 0.01
 
 
+def test_resume_state_seeds_gain_streak_from_legacy_small_improvement_streak():
+    resumed = EarlyStopState.from_resume(None, legacy_gain_streak=3)
+
+    assert resumed.gain_streak == 3
+    assert resumed.step_streak == 0
+    assert resumed.rejected_streak == 0
+
+
+def test_resume_state_prefers_structured_early_stop_state_over_legacy_streak():
+    resumed = EarlyStopState.from_resume(
+        {"gain_streak": 1, "step_streak": 2, "rejected_streak": 0},
+        legacy_gain_streak=5,
+    )
+
+    assert resumed.gain_streak == 1
+    assert resumed.step_streak == 2
+    assert resumed.rejected_streak == 0
+
+
 def test_compute_saving_stops_tiny_accepted_setup_gain_and_step_despite_loss_drift():
     policy = resolve_early_stop_policy(
         enabled=True,

--- a/tests/test_bilevel_setup_alignment.py
+++ b/tests/test_bilevel_setup_alignment.py
@@ -193,6 +193,9 @@ def test_product_setup_path_uses_validation_lm_not_active_lbfgs(monkeypatch):
     assert setup_stats
     assert setup_stats[0]["active_gradient_mode"] == "validation_residual_jvp"
     assert setup_stats[0]["schedule_stage_name"] == "direct_setup"
+    assert setup_stats[0]["early_stop_profile"] == "compute_saving"
+    assert setup_stats[0]["early_stop_decision"] in {"continue", "stop"}
+    assert "accepted_rel_impr" in setup_stats[0]
 
 
 def test_setup_execution_rejects_non_validation_lm_stage_before_running():

--- a/tests/test_geometry_block_taxonomy_generator.py
+++ b/tests/test_geometry_block_taxonomy_generator.py
@@ -57,6 +57,7 @@ def test_geometry_block_taxonomy_docs_profile_matches_historical_run_contract(tm
     assert tuple(manifest["profile"]["levels"]) == (8, 4, 2, 1)
     assert manifest["profile"]["outer_iters"] == 16
     assert manifest["profile"]["early_stop"] is True
+    assert manifest["profile"]["early_stop_profile"] == "compute_saving"
     assert manifest["profile"]["early_stop_rel_impr"] == 1e-3
     assert manifest["profile"]["early_stop_patience"] == 2
     assert manifest["profile"]["views_per_batch"] == 1
@@ -175,6 +176,7 @@ def test_geometry_block_taxonomy_passes_profile_early_stop_to_align_config(monke
     def fake_align_multires(*args, **kwargs):
         cfg = kwargs["cfg"]
         captured["early_stop"] = cfg.early_stop
+        captured["early_stop_profile"] = cfg.early_stop_profile
         captured["early_stop_rel_impr"] = cfg.early_stop_rel_impr
         captured["early_stop_patience"] = cfg.early_stop_patience
         captured["schedule"] = cfg.schedule
@@ -210,6 +212,7 @@ def test_geometry_block_taxonomy_passes_profile_early_stop_to_align_config(monke
 
     assert captured == {
         "early_stop": True,
+        "early_stop_profile": "compute_saving",
         "early_stop_rel_impr": 1e-3,
         "early_stop_patience": 2,
         "schedule": "cor",


### PR DESCRIPTION
## Summary
- Introduce profile-based early-stop policy selection for alignment stages, including setup and pose-stage coordination.
- Thread the new policy through alignment config, checkpointing, CLI, and stage loop/result handling.
- Update geometry block taxonomy and visualisation scripts to support the new alignment workflow.
- Add and refresh tests covering checkpoint behavior, contracts, early-stop logic, bilevel setup alignment, and geometry block generation.
- Document the change in README and related design/solution notes.

## Testing
- Added/updated unit coverage for early-stop policy behavior and alignment contracts.
- Added regression coverage for checkpoint serialization and bilevel setup alignment.
- Added taxonomy generator coverage for geometry block classification.
- Not run (not requested)